### PR TITLE
set private to false for package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "main.js",
   "types": "main.ts",
   "license": "MPL-2.0",
-  "private": true,
+  "private": false,
   "scripts": {
     "get": "cdktf get",
     "build": "tsc",


### PR DESCRIPTION
Set package.json to private: false to publish to internal npm package repo.