### PR TITLE
chore: fix npm publish in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,4 +128,6 @@ jobs:
       - name: Collect js Artifact
         run: mv .repo/dist dist
       - name: Release
-        run: npm publish
+        run: |-
+          PACKAGE_FILE=$(ls dist/js/*.tgz)
+          npm publish "$PACKAGE_FILE"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -85,7 +85,10 @@ releaseWorkflow?.patch(
   }),
 );
 releaseWorkflow?.patch(
-  JsonPatch.add("/jobs/release_npm/steps/8/run", "npm publish"),
+  JsonPatch.add(
+    "/jobs/release_npm/steps/8/run",
+    'PACKAGE_FILE=$(ls dist/js/*.tgz)\nnpm publish "$PACKAGE_FILE"',
+  ),
 );
 
 // Build Workflow


### PR DESCRIPTION
Fixed broken `npm publish` command on release pipeline.