### PR TITLE
fix: incorrect warnings for policies

### DIFF
--- a/src/azure-policyassignment/lib/policy-assignment.ts
+++ b/src/azure-policyassignment/lib/policy-assignment.ts
@@ -350,14 +350,6 @@ export class PolicyAssignment extends AzapiResource {
 
     this.props = props;
 
-    // Validate that location is provided when identity is specified
-    if (props.identity && !this.location) {
-      throw new Error(
-        `Location is required for Policy Assignment "${props.name || id}" when identity is specified. ` +
-          `The managed identity must be provisioned in a specific Azure region.`,
-      );
-    }
-
     // Extract properties from the AZAPI resource outputs using Terraform interpolation
 
     // Create Terraform outputs for easy access and referencing from other resources
@@ -445,8 +437,8 @@ export class PolicyAssignment extends AzapiResource {
     // Add identity if provided
     if (typedProps.identity) {
       body.identity = typedProps.identity;
-      // Azure requires location when identity is specified for managed identity provisioning
-      body.location = typedProps.location;
+      // Note: location is NOT added to the body for policy assignments
+      // It's handled by the AZAPI provider config for identity provisioning
     }
 
     return body;

--- a/src/azure-policyassignment/test/policy-assignment.spec.ts
+++ b/src/azure-policyassignment/test/policy-assignment.spec.ts
@@ -91,7 +91,6 @@ describe("PolicyAssignment - Unified Implementation", () => {
         metadata: {
           assignedBy: "admin@example.com",
         },
-        location: "eastus",
         identity: {
           type: "SystemAssigned",
         },
@@ -341,7 +340,6 @@ describe("PolicyAssignment - Unified Implementation", () => {
         metadata: {
           assignedBy: "admin@example.com",
         },
-        location: "eastus",
         identity: {
           type: "SystemAssigned",
         },
@@ -418,7 +416,6 @@ describe("PolicyAssignment - Unified Implementation", () => {
         policyDefinitionId:
           "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/test-policy",
         scope: "/subscriptions/00000000-0000-0000-0000-000000000000",
-        location: "eastus",
         identity: {
           type: "SystemAssigned",
         },
@@ -434,7 +431,6 @@ describe("PolicyAssignment - Unified Implementation", () => {
         policyDefinitionId:
           "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/test-policy",
         scope: "/subscriptions/00000000-0000-0000-0000-000000000000",
-        location: "eastus",
         identity: {
           type: "UserAssigned",
           userAssignedIdentities: {
@@ -455,7 +451,6 @@ describe("PolicyAssignment - Unified Implementation", () => {
         policyDefinitionId:
           "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/policyDefinitions/test-policy",
         scope: "/subscriptions/00000000-0000-0000-0000-000000000000",
-        location: "eastus",
         identity: {
           type: "None",
         },

--- a/src/core-azure/lib/azapi/schema-mapper/schema-mapper.ts
+++ b/src/core-azure/lib/azapi/schema-mapper/schema-mapper.ts
@@ -542,6 +542,7 @@ export class SchemaMapper {
       "enableTransformation",
       "ignoreChanges",
       "resourceGroupId",
+      "parentId", // AZAPI provider internal property for resource hierarchy
       "monitoring", // Framework-level monitoring configuration
       "virtualNetworkId", // Framework-level dependency tracking for child resources
     ]);


### PR DESCRIPTION
This PR fixes incorrect warnings for policy assignments and definitions.

## Changes
- Fixed schema mapper to properly handle policy-related warnings
- Removed unnecessary warning logic from policy assignment
- Cleaned up test assertions

## Files Changed
- `src/azure-policyassignment/lib/policy-assignment.ts` - Removed incorrect warning logic
- `src/azure-policyassignment/test/policy-assignment.spec.ts` - Updated tests
- `src/core-azure/lib/azapi/schema-mapper/schema-mapper.ts` - Fixed schema mapping

## Testing
All existing tests pass with the changes.