### PR TITLE
fix: update Node.js requirement to >= 20.16.0 for jsii compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.10.0
+          node-version: 20.16.0
       - name: Authenticate with Azure
         id: azure_login
         uses: azure/login@v2
@@ -79,7 +79,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.10.0
+          node-version: 20.16.0
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -103,13 +103,13 @@ jobs:
     permissions: {}
     if: "! needs.build.outputs.self_mutation_happened"
     steps:
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 11.x
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.10.0
+          node-version: 20.16.0
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -135,7 +135,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.10.0
+          node-version: 20.16.0
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -164,8 +164,8 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.10.0
-      - uses: actions/setup-dotnet@v3
+          node-version: 20.16.0
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 3.x
       - name: Download build artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.10.0
+          node-version: 20.16.0
       - name: Authenticate with Azure
         id: azure_login
         uses: azure/login@v2
@@ -76,7 +76,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.10.0
+          node-version: 20.16.0
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.10.0
+          node-version: 20.16.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -22,7 +22,7 @@ const project = new cdktf.ConstructLibraryCdktf({
   ],
   constructsVersion: "^10.3.0",
   typescriptVersion: "~5.9.3", // should always be the same major/minor as JSII
-  minNodeVersion: "20.10.0",
+  minNodeVersion: "20.16.0",
   defaultReleaseBranch: "main",
   name: "@microsoft/terraform-cdk-constructs",
   majorVersion: 1, // Set to version 1.0.0 for AZAPI migration

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "terraform"
   ],
   "engines": {
-    "node": ">= 20.10.0"
+    "node": ">= 20.16.0"
   },
   "main": "lib/index.js",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Fixes CI pipeline failure caused by `jsii@5.9.31` requiring Node.js >= 20.16.0, but the pipeline was using Node.js 20.10.0.

## Error
```
error jsii@5.9.31: The engine "node" is incompatible with this module. Expected version ">= 20.16.0". Got "20.10.0"
```

## Changes
- Updated `minNodeVersion` in `.projenrc.ts` from `20.10.0` to `20.16.0`
- Regenerated workflow files via `npx projen`

## Files Changed
- `.projenrc.ts`
- `.github/workflows/build.yml`
- `.github/workflows/release.yml`
- `.github/workflows/upgrade-main.yml`
- `package.json`

**Note:** This PR's CI may fail due to the chicken-and-egg problem with `pull_request_target` reading workflow files from main. Once merged, subsequent PRs (including cdktn) will pass.