### PR TITLE
fix: add projen action overrides to prevent self-mutation with setup-java and setup-dotnet v4

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -234,6 +234,11 @@ if (upgradeWorkflow) {
   );
 }
 
+// Override GitHub Actions versions to v4 to prevent self-mutation issues
+// This ensures projen generates @v4 versions instead of @v3 defaults
+project.github?.actions.set("actions/setup-java", "actions/setup-java@v4");
+project.github?.actions.set("actions/setup-dotnet", "actions/setup-dotnet@v4");
+
 // Add .gitignore entries
 project.gitignore.include("cdk.out");
 project.gitignore.exclude("cdktf.out");


### PR DESCRIPTION
## Summary

Fixes self-mutation issue where `actions/setup-java` and `actions/setup-dotnet` were being reverted from v4 to v3 during CI builds.

## Changes

Added projen action version overrides in `.projenrc.ts`:

```typescript
project.github?.actions.set("actions/setup-java", "actions/setup-java@v4");
project.github?.actions.set("actions/setup-dotnet", "actions/setup-dotnet@v4");
```

## Why This Fix Works

The self-mutation issue occurred because:
1. The workflow files were manually updated to use v4 versions
2. Projen's default versions are v3, so when `npx projen` ran during CI builds, it regenerated the workflows with v3, causing a diff
3. This fix configures projen to always use v4 for these actions, preventing future self-mutation

## Testing

- Ran `npx projen` locally and verified workflow files maintain v4 versions
- No changes to workflow files when regenerating (no self-mutation)