### PR TITLE
feat: Add Log Analytics Workspace, Network Watcher, and Policy Set Definition constructs

### DIFF
--- a/API.md
+++ b/API.md
@@ -32136,6 +32136,984 @@ public readonly resourceName: string;
 ---
 
 
+### LogAnalyticsWorkspace <a name="LogAnalyticsWorkspace" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace"></a>
+
+Unified Azure Log Analytics Workspace implementation.
+
+This class provides a single, version-aware implementation that automatically handles version
+resolution, schema validation, and property transformation while maintaining full JSII compliance.
+
+Log Analytics Workspace is the central destination for log data from Azure resources,
+applications, and on-premises infrastructure. It enables querying, analysis, and
+visualization of log data using Kusto Query Language (KQL).
+
+*Example*
+
+```typescript
+// Log Analytics Workspace with capacity reservation:
+const workspace = new LogAnalyticsWorkspace(this, "high-volume-workspace", {
+  name: "high-volume-logs",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  retentionInDays: 365,
+  sku: {
+    name: "CapacityReservation",
+    capacityReservationLevel: 500
+  },
+  workspaceCapping: {
+    dailyQuotaGb: 100
+  }
+});
+```
+
+
+#### Initializers <a name="Initializers" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.Initializer"></a>
+
+```typescript
+import { LogAnalyticsWorkspace } from '@microsoft/terraform-cdk-constructs'
+
+new LogAnalyticsWorkspace(scope: Construct, id: string, props: LogAnalyticsWorkspaceProps)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | - The scope in which to define this construct. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.Initializer.parameter.id">id</a></code> | <code>string</code> | - The unique identifier for this instance. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.Initializer.parameter.props">props</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps</code> | - Configuration properties for the Log Analytics Workspace. |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+The scope in which to define this construct.
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.Initializer.parameter.id"></a>
+
+- *Type:* string
+
+The unique identifier for this instance.
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.Initializer.parameter.props"></a>
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps
+
+Configuration properties for the Log Analytics Workspace.
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.addAccess">addAccess</a></code> | Adds an access role assignment for a specified Azure AD object. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.addTag">addTag</a></code> | Adds a tag to this resource. The tag will be included in the Azure resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.analyzeMigrationTo">analyzeMigrationTo</a></code> | Analyzes migration from current version to a target version. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.latestVersion">latestVersion</a></code> | Gets the latest available version for this resource type. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.supportedVersions">supportedVersions</a></code> | Gets all supported versions for this resource type. |
+
+---
+
+##### `toString` <a name="toString" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.toString"></a>
+
+```typescript
+public toString(): string
+```
+
+Returns a string representation of this construct.
+
+##### `addAccess` <a name="addAccess" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.addAccess"></a>
+
+```typescript
+public addAccess(objectId: string, roleDefinitionName: string): void
+```
+
+Adds an access role assignment for a specified Azure AD object.
+
+Note: This method creates role assignments using AZAPI instead of AzureRM provider.
+
+###### `objectId`<sup>Required</sup> <a name="objectId" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.addAccess.parameter.objectId"></a>
+
+- *Type:* string
+
+The unique identifier of the Azure AD object.
+
+---
+
+###### `roleDefinitionName`<sup>Required</sup> <a name="roleDefinitionName" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.addAccess.parameter.roleDefinitionName"></a>
+
+- *Type:* string
+
+The name of the Azure RBAC role to be assigned.
+
+---
+
+##### `addTag` <a name="addTag" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.addTag"></a>
+
+```typescript
+public addTag(key: string, value: string): void
+```
+
+Adds a tag to this resource. The tag will be included in the Azure resource.
+
+This method provides proper immutability by storing tags separately from props.
+Tags added via this method are combined with tags from props and included in
+the deployed Azure resource.
+
+**Important:** In CDK for Terraform, tags should ideally be set during resource
+construction via props. While this method allows adding tags after construction,
+those tags are only included if added before the Terraform configuration is
+synthesized. For best results, add all tags via props or call addTag() in the
+same scope where the resource is created.
+
+###### `key`<sup>Required</sup> <a name="key" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.addTag.parameter.key"></a>
+
+- *Type:* string
+
+The tag key.
+
+---
+
+###### `value`<sup>Required</sup> <a name="value" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.addTag.parameter.value"></a>
+
+- *Type:* string
+
+The tag value.
+
+---
+
+##### `analyzeMigrationTo` <a name="analyzeMigrationTo" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.analyzeMigrationTo"></a>
+
+```typescript
+public analyzeMigrationTo(targetVersion: string): MigrationAnalysis
+```
+
+Analyzes migration from current version to a target version.
+
+This method enables external tools to analyze migration requirements
+between versions for planning and automation purposes.
+
+###### `targetVersion`<sup>Required</sup> <a name="targetVersion" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.analyzeMigrationTo.parameter.targetVersion"></a>
+
+- *Type:* string
+
+The target version to analyze migration to.
+
+---
+
+##### `latestVersion` <a name="latestVersion" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.latestVersion"></a>
+
+```typescript
+public latestVersion(): string
+```
+
+Gets the latest available version for this resource type.
+
+This method provides access to the latest version resolution logic
+for use in subclasses or external tooling.
+
+##### `supportedVersions` <a name="supportedVersions" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.supportedVersions"></a>
+
+```typescript
+public supportedVersions(): string[]
+```
+
+Gets all supported versions for this resource type.
+
+This method provides access to the version registry for use in
+subclasses or external tooling.
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+
+---
+
+##### `isConstruct` <a name="isConstruct" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.isConstruct"></a>
+
+```typescript
+import { LogAnalyticsWorkspace } from '@microsoft/terraform-cdk-constructs'
+
+LogAnalyticsWorkspace.isConstruct(x: any)
+```
+
+Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
+
+###### `x`<sup>Required</sup> <a name="x" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+Any object.
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.id">id</a></code> | <code>string</code> | The Azure resource ID. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.name">name</a></code> | <code>string</code> | The name of the resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.output">output</a></code> | <code>cdktf.TerraformOutput</code> | Gets the resource as a Terraform output value. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.resource">resource</a></code> | <code>cdktf.TerraformResource</code> | Gets the underlying Terraform resource for use in dependency declarations This allows explicit dependency management between resources. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.resourceId">resourceId</a></code> | <code>string</code> | Gets the full resource ID. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.tags">tags</a></code> | <code>{[ key: string ]: string}</code> | All tags on this resource (readonly view). |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.location">location</a></code> | <code>string</code> | The location of the resource (optional - not all resources have a location) Child resources typically inherit location from their parent. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.resolvedApiVersion">resolvedApiVersion</a></code> | <code>string</code> | The resolved API version being used for this resource instance. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.schema">schema</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.ApiSchema</code> | The API schema for the resolved version. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.versionConfig">versionConfig</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.VersionConfig</code> | The version configuration for the resolved version. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.migrationAnalysis">migrationAnalysis</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.MigrationAnalysis</code> | Migration analysis results. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.validationResult">validationResult</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.ValidationResult</code> | Validation results for the resource properties. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.customerIdOutput">customerIdOutput</a></code> | <code>cdktf.TerraformOutput</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.idOutput">idOutput</a></code> | <code>cdktf.TerraformOutput</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.nameOutput">nameOutput</a></code> | <code>cdktf.TerraformOutput</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.props">props</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps</code> | The input properties for this Log Analytics Workspace instance. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.workspaceIdOutput">workspaceIdOutput</a></code> | <code>cdktf.TerraformOutput</code> | *No description.* |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- *Type:* constructs.Node
+
+The tree node.
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.id"></a>
+
+```typescript
+public readonly id: string;
+```
+
+- *Type:* string
+
+The Azure resource ID.
+
+This property is automatically derived from the underlying Terraform resource.
+Child classes no longer need to implement this property.
+
+---
+
+##### `name`<sup>Required</sup> <a name="name" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* string
+
+The name of the resource.
+
+---
+
+##### `output`<sup>Required</sup> <a name="output" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.output"></a>
+
+```typescript
+public readonly output: TerraformOutput;
+```
+
+- *Type:* cdktf.TerraformOutput
+
+Gets the resource as a Terraform output value.
+
+---
+
+##### `resource`<sup>Required</sup> <a name="resource" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.resource"></a>
+
+```typescript
+public readonly resource: TerraformResource;
+```
+
+- *Type:* cdktf.TerraformResource
+
+Gets the underlying Terraform resource for use in dependency declarations This allows explicit dependency management between resources.
+
+---
+
+##### `resourceId`<sup>Required</sup> <a name="resourceId" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.resourceId"></a>
+
+```typescript
+public readonly resourceId: string;
+```
+
+- *Type:* string
+
+Gets the full resource ID.
+
+---
+
+##### `tags`<sup>Required</sup> <a name="tags" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.tags"></a>
+
+```typescript
+public readonly tags: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
+
+All tags on this resource (readonly view).
+
+This getter provides convenient access to all tags including those from props
+and those added dynamically via addTag(). Returns a copy to maintain immutability.
+
+---
+
+##### `location`<sup>Optional</sup> <a name="location" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.location"></a>
+
+```typescript
+public readonly location: string;
+```
+
+- *Type:* string
+
+The location of the resource (optional - not all resources have a location) Child resources typically inherit location from their parent.
+
+---
+
+##### `resolvedApiVersion`<sup>Required</sup> <a name="resolvedApiVersion" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.resolvedApiVersion"></a>
+
+```typescript
+public readonly resolvedApiVersion: string;
+```
+
+- *Type:* string
+
+The resolved API version being used for this resource instance.
+
+This is the actual version that will be used for the Azure API call,
+either explicitly specified in props or automatically resolved to
+the latest active version.
+
+---
+
+##### `schema`<sup>Required</sup> <a name="schema" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.schema"></a>
+
+```typescript
+public readonly schema: ApiSchema;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.ApiSchema
+
+The API schema for the resolved version.
+
+Contains the complete schema definition including properties, validation
+rules, and transformation mappings for the resolved API version.
+
+---
+
+##### `versionConfig`<sup>Required</sup> <a name="versionConfig" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.versionConfig"></a>
+
+```typescript
+public readonly versionConfig: VersionConfig;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.VersionConfig
+
+The version configuration for the resolved version.
+
+Contains lifecycle information, breaking changes, and migration metadata
+for the resolved API version.
+
+---
+
+##### `migrationAnalysis`<sup>Optional</sup> <a name="migrationAnalysis" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.migrationAnalysis"></a>
+
+```typescript
+public readonly migrationAnalysis: MigrationAnalysis;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.MigrationAnalysis
+
+Migration analysis results.
+
+Available after construction if migration analysis is enabled and a
+previous version can be determined for comparison.
+
+---
+
+##### `validationResult`<sup>Optional</sup> <a name="validationResult" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.validationResult"></a>
+
+```typescript
+public readonly validationResult: ValidationResult;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.ValidationResult
+
+Validation results for the resource properties.
+
+Available after construction if validation is enabled. Contains detailed
+information about any validation errors or warnings.
+
+---
+
+##### `customerIdOutput`<sup>Required</sup> <a name="customerIdOutput" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.customerIdOutput"></a>
+
+```typescript
+public readonly customerIdOutput: TerraformOutput;
+```
+
+- *Type:* cdktf.TerraformOutput
+
+---
+
+##### `idOutput`<sup>Required</sup> <a name="idOutput" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.idOutput"></a>
+
+```typescript
+public readonly idOutput: TerraformOutput;
+```
+
+- *Type:* cdktf.TerraformOutput
+
+---
+
+##### `nameOutput`<sup>Required</sup> <a name="nameOutput" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.nameOutput"></a>
+
+```typescript
+public readonly nameOutput: TerraformOutput;
+```
+
+- *Type:* cdktf.TerraformOutput
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.props"></a>
+
+```typescript
+public readonly props: LogAnalyticsWorkspaceProps;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps
+
+The input properties for this Log Analytics Workspace instance.
+
+---
+
+##### `workspaceIdOutput`<sup>Required</sup> <a name="workspaceIdOutput" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspace.property.workspaceIdOutput"></a>
+
+```typescript
+public readonly workspaceIdOutput: TerraformOutput;
+```
+
+- *Type:* cdktf.TerraformOutput
+
+---
+
+
+### LogAnalyticsWorkspace <a name="LogAnalyticsWorkspace" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace"></a>
+
+Unified Azure Log Analytics Workspace implementation.
+
+This class provides a single, version-aware implementation that automatically handles version
+resolution, schema validation, and property transformation while maintaining full JSII compliance.
+
+Log Analytics Workspace is the central destination for log data from Azure resources,
+applications, and on-premises infrastructure. It enables querying, analysis, and
+visualization of log data using Kusto Query Language (KQL).
+
+*Example*
+
+```typescript
+// Log Analytics Workspace with capacity reservation:
+const workspace = new LogAnalyticsWorkspace(this, "high-volume-workspace", {
+  name: "high-volume-logs",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  retentionInDays: 365,
+  sku: {
+    name: "CapacityReservation",
+    capacityReservationLevel: 500
+  },
+  workspaceCapping: {
+    dailyQuotaGb: 100
+  }
+});
+```
+
+
+#### Initializers <a name="Initializers" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.Initializer"></a>
+
+```typescript
+import { azure_loganalyticsworkspace } from '@microsoft/terraform-cdk-constructs'
+
+new azure_loganalyticsworkspace.LogAnalyticsWorkspace(scope: Construct, id: string, props: LogAnalyticsWorkspaceProps)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | - The scope in which to define this construct. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.Initializer.parameter.id">id</a></code> | <code>string</code> | - The unique identifier for this instance. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.Initializer.parameter.props">props</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps</code> | - Configuration properties for the Log Analytics Workspace. |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+The scope in which to define this construct.
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.Initializer.parameter.id"></a>
+
+- *Type:* string
+
+The unique identifier for this instance.
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.Initializer.parameter.props"></a>
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps
+
+Configuration properties for the Log Analytics Workspace.
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.addAccess">addAccess</a></code> | Adds an access role assignment for a specified Azure AD object. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.addTag">addTag</a></code> | Adds a tag to this resource. The tag will be included in the Azure resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.analyzeMigrationTo">analyzeMigrationTo</a></code> | Analyzes migration from current version to a target version. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.latestVersion">latestVersion</a></code> | Gets the latest available version for this resource type. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.supportedVersions">supportedVersions</a></code> | Gets all supported versions for this resource type. |
+
+---
+
+##### `toString` <a name="toString" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.toString"></a>
+
+```typescript
+public toString(): string
+```
+
+Returns a string representation of this construct.
+
+##### `addAccess` <a name="addAccess" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.addAccess"></a>
+
+```typescript
+public addAccess(objectId: string, roleDefinitionName: string): void
+```
+
+Adds an access role assignment for a specified Azure AD object.
+
+Note: This method creates role assignments using AZAPI instead of AzureRM provider.
+
+###### `objectId`<sup>Required</sup> <a name="objectId" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.addAccess.parameter.objectId"></a>
+
+- *Type:* string
+
+The unique identifier of the Azure AD object.
+
+---
+
+###### `roleDefinitionName`<sup>Required</sup> <a name="roleDefinitionName" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.addAccess.parameter.roleDefinitionName"></a>
+
+- *Type:* string
+
+The name of the Azure RBAC role to be assigned.
+
+---
+
+##### `addTag` <a name="addTag" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.addTag"></a>
+
+```typescript
+public addTag(key: string, value: string): void
+```
+
+Adds a tag to this resource. The tag will be included in the Azure resource.
+
+This method provides proper immutability by storing tags separately from props.
+Tags added via this method are combined with tags from props and included in
+the deployed Azure resource.
+
+**Important:** In CDK for Terraform, tags should ideally be set during resource
+construction via props. While this method allows adding tags after construction,
+those tags are only included if added before the Terraform configuration is
+synthesized. For best results, add all tags via props or call addTag() in the
+same scope where the resource is created.
+
+###### `key`<sup>Required</sup> <a name="key" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.addTag.parameter.key"></a>
+
+- *Type:* string
+
+The tag key.
+
+---
+
+###### `value`<sup>Required</sup> <a name="value" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.addTag.parameter.value"></a>
+
+- *Type:* string
+
+The tag value.
+
+---
+
+##### `analyzeMigrationTo` <a name="analyzeMigrationTo" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.analyzeMigrationTo"></a>
+
+```typescript
+public analyzeMigrationTo(targetVersion: string): MigrationAnalysis
+```
+
+Analyzes migration from current version to a target version.
+
+This method enables external tools to analyze migration requirements
+between versions for planning and automation purposes.
+
+###### `targetVersion`<sup>Required</sup> <a name="targetVersion" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.analyzeMigrationTo.parameter.targetVersion"></a>
+
+- *Type:* string
+
+The target version to analyze migration to.
+
+---
+
+##### `latestVersion` <a name="latestVersion" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.latestVersion"></a>
+
+```typescript
+public latestVersion(): string
+```
+
+Gets the latest available version for this resource type.
+
+This method provides access to the latest version resolution logic
+for use in subclasses or external tooling.
+
+##### `supportedVersions` <a name="supportedVersions" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.supportedVersions"></a>
+
+```typescript
+public supportedVersions(): string[]
+```
+
+Gets all supported versions for this resource type.
+
+This method provides access to the version registry for use in
+subclasses or external tooling.
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+
+---
+
+##### `isConstruct` <a name="isConstruct" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.isConstruct"></a>
+
+```typescript
+import { azure_loganalyticsworkspace } from '@microsoft/terraform-cdk-constructs'
+
+azure_loganalyticsworkspace.LogAnalyticsWorkspace.isConstruct(x: any)
+```
+
+Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
+
+###### `x`<sup>Required</sup> <a name="x" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+Any object.
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.id">id</a></code> | <code>string</code> | The Azure resource ID. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.name">name</a></code> | <code>string</code> | The name of the resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.output">output</a></code> | <code>cdktf.TerraformOutput</code> | Gets the resource as a Terraform output value. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.resource">resource</a></code> | <code>cdktf.TerraformResource</code> | Gets the underlying Terraform resource for use in dependency declarations This allows explicit dependency management between resources. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.resourceId">resourceId</a></code> | <code>string</code> | Gets the full resource ID. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.tags">tags</a></code> | <code>{[ key: string ]: string}</code> | All tags on this resource (readonly view). |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.location">location</a></code> | <code>string</code> | The location of the resource (optional - not all resources have a location) Child resources typically inherit location from their parent. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.resolvedApiVersion">resolvedApiVersion</a></code> | <code>string</code> | The resolved API version being used for this resource instance. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.schema">schema</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.ApiSchema</code> | The API schema for the resolved version. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.versionConfig">versionConfig</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.VersionConfig</code> | The version configuration for the resolved version. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.migrationAnalysis">migrationAnalysis</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.MigrationAnalysis</code> | Migration analysis results. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.validationResult">validationResult</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.ValidationResult</code> | Validation results for the resource properties. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.customerIdOutput">customerIdOutput</a></code> | <code>cdktf.TerraformOutput</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.idOutput">idOutput</a></code> | <code>cdktf.TerraformOutput</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.nameOutput">nameOutput</a></code> | <code>cdktf.TerraformOutput</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.props">props</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps</code> | The input properties for this Log Analytics Workspace instance. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.workspaceIdOutput">workspaceIdOutput</a></code> | <code>cdktf.TerraformOutput</code> | *No description.* |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- *Type:* constructs.Node
+
+The tree node.
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.id"></a>
+
+```typescript
+public readonly id: string;
+```
+
+- *Type:* string
+
+The Azure resource ID.
+
+This property is automatically derived from the underlying Terraform resource.
+Child classes no longer need to implement this property.
+
+---
+
+##### `name`<sup>Required</sup> <a name="name" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* string
+
+The name of the resource.
+
+---
+
+##### `output`<sup>Required</sup> <a name="output" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.output"></a>
+
+```typescript
+public readonly output: TerraformOutput;
+```
+
+- *Type:* cdktf.TerraformOutput
+
+Gets the resource as a Terraform output value.
+
+---
+
+##### `resource`<sup>Required</sup> <a name="resource" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.resource"></a>
+
+```typescript
+public readonly resource: TerraformResource;
+```
+
+- *Type:* cdktf.TerraformResource
+
+Gets the underlying Terraform resource for use in dependency declarations This allows explicit dependency management between resources.
+
+---
+
+##### `resourceId`<sup>Required</sup> <a name="resourceId" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.resourceId"></a>
+
+```typescript
+public readonly resourceId: string;
+```
+
+- *Type:* string
+
+Gets the full resource ID.
+
+---
+
+##### `tags`<sup>Required</sup> <a name="tags" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.tags"></a>
+
+```typescript
+public readonly tags: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
+
+All tags on this resource (readonly view).
+
+This getter provides convenient access to all tags including those from props
+and those added dynamically via addTag(). Returns a copy to maintain immutability.
+
+---
+
+##### `location`<sup>Optional</sup> <a name="location" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.location"></a>
+
+```typescript
+public readonly location: string;
+```
+
+- *Type:* string
+
+The location of the resource (optional - not all resources have a location) Child resources typically inherit location from their parent.
+
+---
+
+##### `resolvedApiVersion`<sup>Required</sup> <a name="resolvedApiVersion" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.resolvedApiVersion"></a>
+
+```typescript
+public readonly resolvedApiVersion: string;
+```
+
+- *Type:* string
+
+The resolved API version being used for this resource instance.
+
+This is the actual version that will be used for the Azure API call,
+either explicitly specified in props or automatically resolved to
+the latest active version.
+
+---
+
+##### `schema`<sup>Required</sup> <a name="schema" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.schema"></a>
+
+```typescript
+public readonly schema: ApiSchema;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.ApiSchema
+
+The API schema for the resolved version.
+
+Contains the complete schema definition including properties, validation
+rules, and transformation mappings for the resolved API version.
+
+---
+
+##### `versionConfig`<sup>Required</sup> <a name="versionConfig" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.versionConfig"></a>
+
+```typescript
+public readonly versionConfig: VersionConfig;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.VersionConfig
+
+The version configuration for the resolved version.
+
+Contains lifecycle information, breaking changes, and migration metadata
+for the resolved API version.
+
+---
+
+##### `migrationAnalysis`<sup>Optional</sup> <a name="migrationAnalysis" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.migrationAnalysis"></a>
+
+```typescript
+public readonly migrationAnalysis: MigrationAnalysis;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.MigrationAnalysis
+
+Migration analysis results.
+
+Available after construction if migration analysis is enabled and a
+previous version can be determined for comparison.
+
+---
+
+##### `validationResult`<sup>Optional</sup> <a name="validationResult" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.validationResult"></a>
+
+```typescript
+public readonly validationResult: ValidationResult;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.ValidationResult
+
+Validation results for the resource properties.
+
+Available after construction if validation is enabled. Contains detailed
+information about any validation errors or warnings.
+
+---
+
+##### `customerIdOutput`<sup>Required</sup> <a name="customerIdOutput" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.customerIdOutput"></a>
+
+```typescript
+public readonly customerIdOutput: TerraformOutput;
+```
+
+- *Type:* cdktf.TerraformOutput
+
+---
+
+##### `idOutput`<sup>Required</sup> <a name="idOutput" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.idOutput"></a>
+
+```typescript
+public readonly idOutput: TerraformOutput;
+```
+
+- *Type:* cdktf.TerraformOutput
+
+---
+
+##### `nameOutput`<sup>Required</sup> <a name="nameOutput" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.nameOutput"></a>
+
+```typescript
+public readonly nameOutput: TerraformOutput;
+```
+
+- *Type:* cdktf.TerraformOutput
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.props"></a>
+
+```typescript
+public readonly props: LogAnalyticsWorkspaceProps;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps
+
+The input properties for this Log Analytics Workspace instance.
+
+---
+
+##### `workspaceIdOutput`<sup>Required</sup> <a name="workspaceIdOutput" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspace.property.workspaceIdOutput"></a>
+
+```typescript
+public readonly workspaceIdOutput: TerraformOutput;
+```
+
+- *Type:* cdktf.TerraformOutput
+
+---
+
+
 ### MetricAlert <a name="MetricAlert" id="@microsoft/terraform-cdk-constructs.MetricAlert"></a>
 
 Unified Azure Metric Alert implementation.
@@ -37116,6 +38094,1004 @@ public readonly tagsOutput: TerraformOutput;
 ---
 
 
+### NetworkWatcher <a name="NetworkWatcher" id="@microsoft/terraform-cdk-constructs.NetworkWatcher"></a>
+
+Unified Azure Network Watcher implementation.
+
+This class provides a single, version-aware implementation that automatically handles version
+resolution, schema validation, and property transformation while maintaining full JSII compliance.
+
+Network Watcher is a regional service that provides tools to monitor, diagnose, and gain
+insights into your network health and performance in Azure. It serves as the anchor for
+Network Watcher features like Flow Logs, Connection Monitor, and Packet Capture.
+
+IMPORTANT CONSTRAINT: Azure only allows one Network Watcher per subscription per region.
+If you need Network Watcher functionality in multiple regions, you must create a separate
+Network Watcher for each region.
+
+*Example*
+
+```typescript
+// Network Watcher for use with Flow Logs:
+const networkWatcher = new NetworkWatcher(this, "network-watcher", {
+  name: "NetworkWatcher_eastus",
+  location: "eastus",
+  resourceGroupId: networkWatcherRg.id,
+});
+
+// Then use it with NSG Flow Logs
+const flowLog = new NsgFlowLog(this, "flow-log", {
+  networkWatcherId: networkWatcher.id,
+  // ... other properties
+});
+```
+
+
+#### Initializers <a name="Initializers" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.Initializer"></a>
+
+```typescript
+import { NetworkWatcher } from '@microsoft/terraform-cdk-constructs'
+
+new NetworkWatcher(scope: Construct, id: string, props: NetworkWatcherProps)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcher.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | - The scope in which to define this construct. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcher.Initializer.parameter.id">id</a></code> | <code>string</code> | - The unique identifier for this instance. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcher.Initializer.parameter.props">props</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps</code> | - Configuration properties for the Network Watcher. |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+The scope in which to define this construct.
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.Initializer.parameter.id"></a>
+
+- *Type:* string
+
+The unique identifier for this instance.
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.Initializer.parameter.props"></a>
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps
+
+Configuration properties for the Network Watcher.
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcher.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcher.addAccess">addAccess</a></code> | Adds an access role assignment for a specified Azure AD object. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcher.addTag">addTag</a></code> | Adds a tag to this resource. The tag will be included in the Azure resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcher.analyzeMigrationTo">analyzeMigrationTo</a></code> | Analyzes migration from current version to a target version. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcher.latestVersion">latestVersion</a></code> | Gets the latest available version for this resource type. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcher.supportedVersions">supportedVersions</a></code> | Gets all supported versions for this resource type. |
+
+---
+
+##### `toString` <a name="toString" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.toString"></a>
+
+```typescript
+public toString(): string
+```
+
+Returns a string representation of this construct.
+
+##### `addAccess` <a name="addAccess" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.addAccess"></a>
+
+```typescript
+public addAccess(objectId: string, roleDefinitionName: string): void
+```
+
+Adds an access role assignment for a specified Azure AD object.
+
+Note: This method creates role assignments using AZAPI instead of AzureRM provider.
+
+###### `objectId`<sup>Required</sup> <a name="objectId" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.addAccess.parameter.objectId"></a>
+
+- *Type:* string
+
+The unique identifier of the Azure AD object.
+
+---
+
+###### `roleDefinitionName`<sup>Required</sup> <a name="roleDefinitionName" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.addAccess.parameter.roleDefinitionName"></a>
+
+- *Type:* string
+
+The name of the Azure RBAC role to be assigned.
+
+---
+
+##### `addTag` <a name="addTag" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.addTag"></a>
+
+```typescript
+public addTag(key: string, value: string): void
+```
+
+Adds a tag to this resource. The tag will be included in the Azure resource.
+
+This method provides proper immutability by storing tags separately from props.
+Tags added via this method are combined with tags from props and included in
+the deployed Azure resource.
+
+**Important:** In CDK for Terraform, tags should ideally be set during resource
+construction via props. While this method allows adding tags after construction,
+those tags are only included if added before the Terraform configuration is
+synthesized. For best results, add all tags via props or call addTag() in the
+same scope where the resource is created.
+
+###### `key`<sup>Required</sup> <a name="key" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.addTag.parameter.key"></a>
+
+- *Type:* string
+
+The tag key.
+
+---
+
+###### `value`<sup>Required</sup> <a name="value" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.addTag.parameter.value"></a>
+
+- *Type:* string
+
+The tag value.
+
+---
+
+##### `analyzeMigrationTo` <a name="analyzeMigrationTo" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.analyzeMigrationTo"></a>
+
+```typescript
+public analyzeMigrationTo(targetVersion: string): MigrationAnalysis
+```
+
+Analyzes migration from current version to a target version.
+
+This method enables external tools to analyze migration requirements
+between versions for planning and automation purposes.
+
+###### `targetVersion`<sup>Required</sup> <a name="targetVersion" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.analyzeMigrationTo.parameter.targetVersion"></a>
+
+- *Type:* string
+
+The target version to analyze migration to.
+
+---
+
+##### `latestVersion` <a name="latestVersion" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.latestVersion"></a>
+
+```typescript
+public latestVersion(): string
+```
+
+Gets the latest available version for this resource type.
+
+This method provides access to the latest version resolution logic
+for use in subclasses or external tooling.
+
+##### `supportedVersions` <a name="supportedVersions" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.supportedVersions"></a>
+
+```typescript
+public supportedVersions(): string[]
+```
+
+Gets all supported versions for this resource type.
+
+This method provides access to the version registry for use in
+subclasses or external tooling.
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcher.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+
+---
+
+##### `isConstruct` <a name="isConstruct" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.isConstruct"></a>
+
+```typescript
+import { NetworkWatcher } from '@microsoft/terraform-cdk-constructs'
+
+NetworkWatcher.isConstruct(x: any)
+```
+
+Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
+
+###### `x`<sup>Required</sup> <a name="x" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+Any object.
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcher.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcher.property.id">id</a></code> | <code>string</code> | The Azure resource ID. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcher.property.name">name</a></code> | <code>string</code> | The name of the resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcher.property.output">output</a></code> | <code>cdktf.TerraformOutput</code> | Gets the resource as a Terraform output value. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcher.property.resource">resource</a></code> | <code>cdktf.TerraformResource</code> | Gets the underlying Terraform resource for use in dependency declarations This allows explicit dependency management between resources. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcher.property.resourceId">resourceId</a></code> | <code>string</code> | Gets the full resource ID. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcher.property.tags">tags</a></code> | <code>{[ key: string ]: string}</code> | All tags on this resource (readonly view). |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcher.property.location">location</a></code> | <code>string</code> | The location of the resource (optional - not all resources have a location) Child resources typically inherit location from their parent. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcher.property.resolvedApiVersion">resolvedApiVersion</a></code> | <code>string</code> | The resolved API version being used for this resource instance. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcher.property.schema">schema</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.ApiSchema</code> | The API schema for the resolved version. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcher.property.versionConfig">versionConfig</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.VersionConfig</code> | The version configuration for the resolved version. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcher.property.migrationAnalysis">migrationAnalysis</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.MigrationAnalysis</code> | Migration analysis results. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcher.property.validationResult">validationResult</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.ValidationResult</code> | Validation results for the resource properties. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcher.property.idOutput">idOutput</a></code> | <code>cdktf.TerraformOutput</code> | Terraform output for the Network Watcher resource ID. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcher.property.locationOutput">locationOutput</a></code> | <code>cdktf.TerraformOutput</code> | Terraform output for the Network Watcher location. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcher.property.nameOutput">nameOutput</a></code> | <code>cdktf.TerraformOutput</code> | Terraform output for the Network Watcher name. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcher.property.props">props</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps</code> | The input properties for this Network Watcher instance. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcher.property.provisioningStateOutput">provisioningStateOutput</a></code> | <code>cdktf.TerraformOutput</code> | Terraform output for the Network Watcher provisioning state. |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- *Type:* constructs.Node
+
+The tree node.
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.property.id"></a>
+
+```typescript
+public readonly id: string;
+```
+
+- *Type:* string
+
+The Azure resource ID.
+
+This property is automatically derived from the underlying Terraform resource.
+Child classes no longer need to implement this property.
+
+---
+
+##### `name`<sup>Required</sup> <a name="name" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* string
+
+The name of the resource.
+
+---
+
+##### `output`<sup>Required</sup> <a name="output" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.property.output"></a>
+
+```typescript
+public readonly output: TerraformOutput;
+```
+
+- *Type:* cdktf.TerraformOutput
+
+Gets the resource as a Terraform output value.
+
+---
+
+##### `resource`<sup>Required</sup> <a name="resource" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.property.resource"></a>
+
+```typescript
+public readonly resource: TerraformResource;
+```
+
+- *Type:* cdktf.TerraformResource
+
+Gets the underlying Terraform resource for use in dependency declarations This allows explicit dependency management between resources.
+
+---
+
+##### `resourceId`<sup>Required</sup> <a name="resourceId" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.property.resourceId"></a>
+
+```typescript
+public readonly resourceId: string;
+```
+
+- *Type:* string
+
+Gets the full resource ID.
+
+---
+
+##### `tags`<sup>Required</sup> <a name="tags" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.property.tags"></a>
+
+```typescript
+public readonly tags: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
+
+All tags on this resource (readonly view).
+
+This getter provides convenient access to all tags including those from props
+and those added dynamically via addTag(). Returns a copy to maintain immutability.
+
+---
+
+##### `location`<sup>Optional</sup> <a name="location" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.property.location"></a>
+
+```typescript
+public readonly location: string;
+```
+
+- *Type:* string
+
+The location of the resource (optional - not all resources have a location) Child resources typically inherit location from their parent.
+
+---
+
+##### `resolvedApiVersion`<sup>Required</sup> <a name="resolvedApiVersion" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.property.resolvedApiVersion"></a>
+
+```typescript
+public readonly resolvedApiVersion: string;
+```
+
+- *Type:* string
+
+The resolved API version being used for this resource instance.
+
+This is the actual version that will be used for the Azure API call,
+either explicitly specified in props or automatically resolved to
+the latest active version.
+
+---
+
+##### `schema`<sup>Required</sup> <a name="schema" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.property.schema"></a>
+
+```typescript
+public readonly schema: ApiSchema;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.ApiSchema
+
+The API schema for the resolved version.
+
+Contains the complete schema definition including properties, validation
+rules, and transformation mappings for the resolved API version.
+
+---
+
+##### `versionConfig`<sup>Required</sup> <a name="versionConfig" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.property.versionConfig"></a>
+
+```typescript
+public readonly versionConfig: VersionConfig;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.VersionConfig
+
+The version configuration for the resolved version.
+
+Contains lifecycle information, breaking changes, and migration metadata
+for the resolved API version.
+
+---
+
+##### `migrationAnalysis`<sup>Optional</sup> <a name="migrationAnalysis" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.property.migrationAnalysis"></a>
+
+```typescript
+public readonly migrationAnalysis: MigrationAnalysis;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.MigrationAnalysis
+
+Migration analysis results.
+
+Available after construction if migration analysis is enabled and a
+previous version can be determined for comparison.
+
+---
+
+##### `validationResult`<sup>Optional</sup> <a name="validationResult" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.property.validationResult"></a>
+
+```typescript
+public readonly validationResult: ValidationResult;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.ValidationResult
+
+Validation results for the resource properties.
+
+Available after construction if validation is enabled. Contains detailed
+information about any validation errors or warnings.
+
+---
+
+##### `idOutput`<sup>Required</sup> <a name="idOutput" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.property.idOutput"></a>
+
+```typescript
+public readonly idOutput: TerraformOutput;
+```
+
+- *Type:* cdktf.TerraformOutput
+
+Terraform output for the Network Watcher resource ID.
+
+---
+
+##### `locationOutput`<sup>Required</sup> <a name="locationOutput" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.property.locationOutput"></a>
+
+```typescript
+public readonly locationOutput: TerraformOutput;
+```
+
+- *Type:* cdktf.TerraformOutput
+
+Terraform output for the Network Watcher location.
+
+---
+
+##### `nameOutput`<sup>Required</sup> <a name="nameOutput" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.property.nameOutput"></a>
+
+```typescript
+public readonly nameOutput: TerraformOutput;
+```
+
+- *Type:* cdktf.TerraformOutput
+
+Terraform output for the Network Watcher name.
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.property.props"></a>
+
+```typescript
+public readonly props: NetworkWatcherProps;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps
+
+The input properties for this Network Watcher instance.
+
+---
+
+##### `provisioningStateOutput`<sup>Required</sup> <a name="provisioningStateOutput" id="@microsoft/terraform-cdk-constructs.NetworkWatcher.property.provisioningStateOutput"></a>
+
+```typescript
+public readonly provisioningStateOutput: TerraformOutput;
+```
+
+- *Type:* cdktf.TerraformOutput
+
+Terraform output for the Network Watcher provisioning state.
+
+---
+
+
+### NetworkWatcher <a name="NetworkWatcher" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher"></a>
+
+Unified Azure Network Watcher implementation.
+
+This class provides a single, version-aware implementation that automatically handles version
+resolution, schema validation, and property transformation while maintaining full JSII compliance.
+
+Network Watcher is a regional service that provides tools to monitor, diagnose, and gain
+insights into your network health and performance in Azure. It serves as the anchor for
+Network Watcher features like Flow Logs, Connection Monitor, and Packet Capture.
+
+IMPORTANT CONSTRAINT: Azure only allows one Network Watcher per subscription per region.
+If you need Network Watcher functionality in multiple regions, you must create a separate
+Network Watcher for each region.
+
+*Example*
+
+```typescript
+// Network Watcher for use with Flow Logs:
+const networkWatcher = new NetworkWatcher(this, "network-watcher", {
+  name: "NetworkWatcher_eastus",
+  location: "eastus",
+  resourceGroupId: networkWatcherRg.id,
+});
+
+// Then use it with NSG Flow Logs
+const flowLog = new NsgFlowLog(this, "flow-log", {
+  networkWatcherId: networkWatcher.id,
+  // ... other properties
+});
+```
+
+
+#### Initializers <a name="Initializers" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.Initializer"></a>
+
+```typescript
+import { azure_networkwatcher } from '@microsoft/terraform-cdk-constructs'
+
+new azure_networkwatcher.NetworkWatcher(scope: Construct, id: string, props: NetworkWatcherProps)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | - The scope in which to define this construct. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.Initializer.parameter.id">id</a></code> | <code>string</code> | - The unique identifier for this instance. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.Initializer.parameter.props">props</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps</code> | - Configuration properties for the Network Watcher. |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+The scope in which to define this construct.
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.Initializer.parameter.id"></a>
+
+- *Type:* string
+
+The unique identifier for this instance.
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.Initializer.parameter.props"></a>
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps
+
+Configuration properties for the Network Watcher.
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.addAccess">addAccess</a></code> | Adds an access role assignment for a specified Azure AD object. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.addTag">addTag</a></code> | Adds a tag to this resource. The tag will be included in the Azure resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.analyzeMigrationTo">analyzeMigrationTo</a></code> | Analyzes migration from current version to a target version. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.latestVersion">latestVersion</a></code> | Gets the latest available version for this resource type. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.supportedVersions">supportedVersions</a></code> | Gets all supported versions for this resource type. |
+
+---
+
+##### `toString` <a name="toString" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.toString"></a>
+
+```typescript
+public toString(): string
+```
+
+Returns a string representation of this construct.
+
+##### `addAccess` <a name="addAccess" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.addAccess"></a>
+
+```typescript
+public addAccess(objectId: string, roleDefinitionName: string): void
+```
+
+Adds an access role assignment for a specified Azure AD object.
+
+Note: This method creates role assignments using AZAPI instead of AzureRM provider.
+
+###### `objectId`<sup>Required</sup> <a name="objectId" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.addAccess.parameter.objectId"></a>
+
+- *Type:* string
+
+The unique identifier of the Azure AD object.
+
+---
+
+###### `roleDefinitionName`<sup>Required</sup> <a name="roleDefinitionName" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.addAccess.parameter.roleDefinitionName"></a>
+
+- *Type:* string
+
+The name of the Azure RBAC role to be assigned.
+
+---
+
+##### `addTag` <a name="addTag" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.addTag"></a>
+
+```typescript
+public addTag(key: string, value: string): void
+```
+
+Adds a tag to this resource. The tag will be included in the Azure resource.
+
+This method provides proper immutability by storing tags separately from props.
+Tags added via this method are combined with tags from props and included in
+the deployed Azure resource.
+
+**Important:** In CDK for Terraform, tags should ideally be set during resource
+construction via props. While this method allows adding tags after construction,
+those tags are only included if added before the Terraform configuration is
+synthesized. For best results, add all tags via props or call addTag() in the
+same scope where the resource is created.
+
+###### `key`<sup>Required</sup> <a name="key" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.addTag.parameter.key"></a>
+
+- *Type:* string
+
+The tag key.
+
+---
+
+###### `value`<sup>Required</sup> <a name="value" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.addTag.parameter.value"></a>
+
+- *Type:* string
+
+The tag value.
+
+---
+
+##### `analyzeMigrationTo` <a name="analyzeMigrationTo" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.analyzeMigrationTo"></a>
+
+```typescript
+public analyzeMigrationTo(targetVersion: string): MigrationAnalysis
+```
+
+Analyzes migration from current version to a target version.
+
+This method enables external tools to analyze migration requirements
+between versions for planning and automation purposes.
+
+###### `targetVersion`<sup>Required</sup> <a name="targetVersion" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.analyzeMigrationTo.parameter.targetVersion"></a>
+
+- *Type:* string
+
+The target version to analyze migration to.
+
+---
+
+##### `latestVersion` <a name="latestVersion" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.latestVersion"></a>
+
+```typescript
+public latestVersion(): string
+```
+
+Gets the latest available version for this resource type.
+
+This method provides access to the latest version resolution logic
+for use in subclasses or external tooling.
+
+##### `supportedVersions` <a name="supportedVersions" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.supportedVersions"></a>
+
+```typescript
+public supportedVersions(): string[]
+```
+
+Gets all supported versions for this resource type.
+
+This method provides access to the version registry for use in
+subclasses or external tooling.
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+
+---
+
+##### `isConstruct` <a name="isConstruct" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.isConstruct"></a>
+
+```typescript
+import { azure_networkwatcher } from '@microsoft/terraform-cdk-constructs'
+
+azure_networkwatcher.NetworkWatcher.isConstruct(x: any)
+```
+
+Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
+
+###### `x`<sup>Required</sup> <a name="x" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+Any object.
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.id">id</a></code> | <code>string</code> | The Azure resource ID. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.name">name</a></code> | <code>string</code> | The name of the resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.output">output</a></code> | <code>cdktf.TerraformOutput</code> | Gets the resource as a Terraform output value. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.resource">resource</a></code> | <code>cdktf.TerraformResource</code> | Gets the underlying Terraform resource for use in dependency declarations This allows explicit dependency management between resources. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.resourceId">resourceId</a></code> | <code>string</code> | Gets the full resource ID. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.tags">tags</a></code> | <code>{[ key: string ]: string}</code> | All tags on this resource (readonly view). |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.location">location</a></code> | <code>string</code> | The location of the resource (optional - not all resources have a location) Child resources typically inherit location from their parent. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.resolvedApiVersion">resolvedApiVersion</a></code> | <code>string</code> | The resolved API version being used for this resource instance. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.schema">schema</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.ApiSchema</code> | The API schema for the resolved version. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.versionConfig">versionConfig</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.VersionConfig</code> | The version configuration for the resolved version. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.migrationAnalysis">migrationAnalysis</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.MigrationAnalysis</code> | Migration analysis results. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.validationResult">validationResult</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.ValidationResult</code> | Validation results for the resource properties. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.idOutput">idOutput</a></code> | <code>cdktf.TerraformOutput</code> | Terraform output for the Network Watcher resource ID. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.locationOutput">locationOutput</a></code> | <code>cdktf.TerraformOutput</code> | Terraform output for the Network Watcher location. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.nameOutput">nameOutput</a></code> | <code>cdktf.TerraformOutput</code> | Terraform output for the Network Watcher name. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.props">props</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps</code> | The input properties for this Network Watcher instance. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.provisioningStateOutput">provisioningStateOutput</a></code> | <code>cdktf.TerraformOutput</code> | Terraform output for the Network Watcher provisioning state. |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- *Type:* constructs.Node
+
+The tree node.
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.id"></a>
+
+```typescript
+public readonly id: string;
+```
+
+- *Type:* string
+
+The Azure resource ID.
+
+This property is automatically derived from the underlying Terraform resource.
+Child classes no longer need to implement this property.
+
+---
+
+##### `name`<sup>Required</sup> <a name="name" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* string
+
+The name of the resource.
+
+---
+
+##### `output`<sup>Required</sup> <a name="output" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.output"></a>
+
+```typescript
+public readonly output: TerraformOutput;
+```
+
+- *Type:* cdktf.TerraformOutput
+
+Gets the resource as a Terraform output value.
+
+---
+
+##### `resource`<sup>Required</sup> <a name="resource" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.resource"></a>
+
+```typescript
+public readonly resource: TerraformResource;
+```
+
+- *Type:* cdktf.TerraformResource
+
+Gets the underlying Terraform resource for use in dependency declarations This allows explicit dependency management between resources.
+
+---
+
+##### `resourceId`<sup>Required</sup> <a name="resourceId" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.resourceId"></a>
+
+```typescript
+public readonly resourceId: string;
+```
+
+- *Type:* string
+
+Gets the full resource ID.
+
+---
+
+##### `tags`<sup>Required</sup> <a name="tags" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.tags"></a>
+
+```typescript
+public readonly tags: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
+
+All tags on this resource (readonly view).
+
+This getter provides convenient access to all tags including those from props
+and those added dynamically via addTag(). Returns a copy to maintain immutability.
+
+---
+
+##### `location`<sup>Optional</sup> <a name="location" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.location"></a>
+
+```typescript
+public readonly location: string;
+```
+
+- *Type:* string
+
+The location of the resource (optional - not all resources have a location) Child resources typically inherit location from their parent.
+
+---
+
+##### `resolvedApiVersion`<sup>Required</sup> <a name="resolvedApiVersion" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.resolvedApiVersion"></a>
+
+```typescript
+public readonly resolvedApiVersion: string;
+```
+
+- *Type:* string
+
+The resolved API version being used for this resource instance.
+
+This is the actual version that will be used for the Azure API call,
+either explicitly specified in props or automatically resolved to
+the latest active version.
+
+---
+
+##### `schema`<sup>Required</sup> <a name="schema" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.schema"></a>
+
+```typescript
+public readonly schema: ApiSchema;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.ApiSchema
+
+The API schema for the resolved version.
+
+Contains the complete schema definition including properties, validation
+rules, and transformation mappings for the resolved API version.
+
+---
+
+##### `versionConfig`<sup>Required</sup> <a name="versionConfig" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.versionConfig"></a>
+
+```typescript
+public readonly versionConfig: VersionConfig;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.VersionConfig
+
+The version configuration for the resolved version.
+
+Contains lifecycle information, breaking changes, and migration metadata
+for the resolved API version.
+
+---
+
+##### `migrationAnalysis`<sup>Optional</sup> <a name="migrationAnalysis" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.migrationAnalysis"></a>
+
+```typescript
+public readonly migrationAnalysis: MigrationAnalysis;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.MigrationAnalysis
+
+Migration analysis results.
+
+Available after construction if migration analysis is enabled and a
+previous version can be determined for comparison.
+
+---
+
+##### `validationResult`<sup>Optional</sup> <a name="validationResult" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.validationResult"></a>
+
+```typescript
+public readonly validationResult: ValidationResult;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.ValidationResult
+
+Validation results for the resource properties.
+
+Available after construction if validation is enabled. Contains detailed
+information about any validation errors or warnings.
+
+---
+
+##### `idOutput`<sup>Required</sup> <a name="idOutput" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.idOutput"></a>
+
+```typescript
+public readonly idOutput: TerraformOutput;
+```
+
+- *Type:* cdktf.TerraformOutput
+
+Terraform output for the Network Watcher resource ID.
+
+---
+
+##### `locationOutput`<sup>Required</sup> <a name="locationOutput" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.locationOutput"></a>
+
+```typescript
+public readonly locationOutput: TerraformOutput;
+```
+
+- *Type:* cdktf.TerraformOutput
+
+Terraform output for the Network Watcher location.
+
+---
+
+##### `nameOutput`<sup>Required</sup> <a name="nameOutput" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.nameOutput"></a>
+
+```typescript
+public readonly nameOutput: TerraformOutput;
+```
+
+- *Type:* cdktf.TerraformOutput
+
+Terraform output for the Network Watcher name.
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.props"></a>
+
+```typescript
+public readonly props: NetworkWatcherProps;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps
+
+The input properties for this Network Watcher instance.
+
+---
+
+##### `provisioningStateOutput`<sup>Required</sup> <a name="provisioningStateOutput" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcher.property.provisioningStateOutput"></a>
+
+```typescript
+public readonly provisioningStateOutput: TerraformOutput;
+```
+
+- *Type:* cdktf.TerraformOutput
+
+Terraform output for the Network Watcher provisioning state.
+
+---
+
+
 ### PolicyAssignment <a name="PolicyAssignment" id="@microsoft/terraform-cdk-constructs.PolicyAssignment"></a>
 
 Unified Azure Policy Assignment implementation.
@@ -39106,6 +41082,1064 @@ public readonly props: PolicyDefinitionProps;
 - *Type:* @microsoft/terraform-cdk-constructs.azure_policydefinition.PolicyDefinitionProps
 
 The input properties for this Policy Definition instance.
+
+---
+
+
+### PolicySetDefinition <a name="PolicySetDefinition" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition"></a>
+
+Unified Azure Policy Set Definition (Initiative) implementation.
+
+This class provides a single, version-aware implementation for managing Azure
+Policy Set Definitions. It automatically handles version resolution, schema validation,
+and property transformation.
+
+Policy Set Definitions allow you to group multiple policy definitions together
+and assign them as a single unit (also known as "Initiatives" in Azure Portal).
+
+Note: Policy set definitions are created at subscription or management group scope.
+They do not have a location property as they are not region-specific.
+
+*Example*
+
+```typescript
+const initiative = new PolicySetDefinition(this, "security-initiative", {
+  displayName: "Security Baseline",
+  scope: "/subscriptions/00000000-0000-0000-0000-000000000000",
+  policyDefinitions: [
+    {
+      policyDefinitionId: "/providers/Microsoft.Authorization/policyDefinitions/abc123",
+      policyDefinitionReferenceId: "auditVMsWithoutExtensions",
+    },
+  ],
+});
+```
+
+
+#### Initializers <a name="Initializers" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.Initializer"></a>
+
+```typescript
+import { PolicySetDefinition } from '@microsoft/terraform-cdk-constructs'
+
+new PolicySetDefinition(scope: Construct, id: string, props: PolicySetDefinitionProps)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | - The scope in which to define this construct. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.Initializer.parameter.id">id</a></code> | <code>string</code> | - The unique identifier for this instance. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.Initializer.parameter.props">props</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps</code> | - Configuration properties for the Policy Set Definition. |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+The scope in which to define this construct.
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.Initializer.parameter.id"></a>
+
+- *Type:* string
+
+The unique identifier for this instance.
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.Initializer.parameter.props"></a>
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps
+
+Configuration properties for the Policy Set Definition.
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.addAccess">addAccess</a></code> | Adds an access role assignment for a specified Azure AD object. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.addTag">addTag</a></code> | Adds a tag to this resource. The tag will be included in the Azure resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.analyzeMigrationTo">analyzeMigrationTo</a></code> | Analyzes migration from current version to a target version. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.latestVersion">latestVersion</a></code> | Gets the latest available version for this resource type. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.supportedVersions">supportedVersions</a></code> | Gets all supported versions for this resource type. |
+
+---
+
+##### `toString` <a name="toString" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.toString"></a>
+
+```typescript
+public toString(): string
+```
+
+Returns a string representation of this construct.
+
+##### `addAccess` <a name="addAccess" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.addAccess"></a>
+
+```typescript
+public addAccess(objectId: string, roleDefinitionName: string): void
+```
+
+Adds an access role assignment for a specified Azure AD object.
+
+Note: This method creates role assignments using AZAPI instead of AzureRM provider.
+
+###### `objectId`<sup>Required</sup> <a name="objectId" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.addAccess.parameter.objectId"></a>
+
+- *Type:* string
+
+The unique identifier of the Azure AD object.
+
+---
+
+###### `roleDefinitionName`<sup>Required</sup> <a name="roleDefinitionName" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.addAccess.parameter.roleDefinitionName"></a>
+
+- *Type:* string
+
+The name of the Azure RBAC role to be assigned.
+
+---
+
+##### `addTag` <a name="addTag" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.addTag"></a>
+
+```typescript
+public addTag(key: string, value: string): void
+```
+
+Adds a tag to this resource. The tag will be included in the Azure resource.
+
+This method provides proper immutability by storing tags separately from props.
+Tags added via this method are combined with tags from props and included in
+the deployed Azure resource.
+
+**Important:** In CDK for Terraform, tags should ideally be set during resource
+construction via props. While this method allows adding tags after construction,
+those tags are only included if added before the Terraform configuration is
+synthesized. For best results, add all tags via props or call addTag() in the
+same scope where the resource is created.
+
+###### `key`<sup>Required</sup> <a name="key" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.addTag.parameter.key"></a>
+
+- *Type:* string
+
+The tag key.
+
+---
+
+###### `value`<sup>Required</sup> <a name="value" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.addTag.parameter.value"></a>
+
+- *Type:* string
+
+The tag value.
+
+---
+
+##### `analyzeMigrationTo` <a name="analyzeMigrationTo" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.analyzeMigrationTo"></a>
+
+```typescript
+public analyzeMigrationTo(targetVersion: string): MigrationAnalysis
+```
+
+Analyzes migration from current version to a target version.
+
+This method enables external tools to analyze migration requirements
+between versions for planning and automation purposes.
+
+###### `targetVersion`<sup>Required</sup> <a name="targetVersion" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.analyzeMigrationTo.parameter.targetVersion"></a>
+
+- *Type:* string
+
+The target version to analyze migration to.
+
+---
+
+##### `latestVersion` <a name="latestVersion" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.latestVersion"></a>
+
+```typescript
+public latestVersion(): string
+```
+
+Gets the latest available version for this resource type.
+
+This method provides access to the latest version resolution logic
+for use in subclasses or external tooling.
+
+##### `supportedVersions` <a name="supportedVersions" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.supportedVersions"></a>
+
+```typescript
+public supportedVersions(): string[]
+```
+
+Gets all supported versions for this resource type.
+
+This method provides access to the version registry for use in
+subclasses or external tooling.
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+
+---
+
+##### `isConstruct` <a name="isConstruct" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.isConstruct"></a>
+
+```typescript
+import { PolicySetDefinition } from '@microsoft/terraform-cdk-constructs'
+
+PolicySetDefinition.isConstruct(x: any)
+```
+
+Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
+
+###### `x`<sup>Required</sup> <a name="x" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+Any object.
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.id">id</a></code> | <code>string</code> | The Azure resource ID. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.name">name</a></code> | <code>string</code> | The name of the resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.output">output</a></code> | <code>cdktf.TerraformOutput</code> | Gets the resource as a Terraform output value. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.resource">resource</a></code> | <code>cdktf.TerraformResource</code> | Gets the underlying Terraform resource for use in dependency declarations This allows explicit dependency management between resources. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.resourceId">resourceId</a></code> | <code>string</code> | Gets the full resource ID. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.tags">tags</a></code> | <code>{[ key: string ]: string}</code> | All tags on this resource (readonly view). |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.location">location</a></code> | <code>string</code> | The location of the resource (optional - not all resources have a location) Child resources typically inherit location from their parent. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.resolvedApiVersion">resolvedApiVersion</a></code> | <code>string</code> | The resolved API version being used for this resource instance. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.schema">schema</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.ApiSchema</code> | The API schema for the resolved version. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.versionConfig">versionConfig</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.VersionConfig</code> | The version configuration for the resolved version. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.migrationAnalysis">migrationAnalysis</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.MigrationAnalysis</code> | Migration analysis results. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.validationResult">validationResult</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.ValidationResult</code> | Validation results for the resource properties. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.displayName">displayName</a></code> | <code>string</code> | Get the display name of the policy set definition. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.idOutput">idOutput</a></code> | <code>cdktf.TerraformOutput</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.nameOutput">nameOutput</a></code> | <code>cdktf.TerraformOutput</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.policyDefinitionCount">policyDefinitionCount</a></code> | <code>number</code> | Get the number of policy definitions in this set. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.policySetDefinitionId">policySetDefinitionId</a></code> | <code>string</code> | Get the full resource identifier for use in policy assignments Alias for the id property. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.policySetDefinitionIdOutput">policySetDefinitionIdOutput</a></code> | <code>cdktf.TerraformOutput</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.policyType">policyType</a></code> | <code>string</code> | Get the policy type. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.props">props</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps</code> | The input properties for this Policy Set Definition instance. |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- *Type:* constructs.Node
+
+The tree node.
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.id"></a>
+
+```typescript
+public readonly id: string;
+```
+
+- *Type:* string
+
+The Azure resource ID.
+
+This property is automatically derived from the underlying Terraform resource.
+Child classes no longer need to implement this property.
+
+---
+
+##### `name`<sup>Required</sup> <a name="name" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* string
+
+The name of the resource.
+
+---
+
+##### `output`<sup>Required</sup> <a name="output" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.output"></a>
+
+```typescript
+public readonly output: TerraformOutput;
+```
+
+- *Type:* cdktf.TerraformOutput
+
+Gets the resource as a Terraform output value.
+
+---
+
+##### `resource`<sup>Required</sup> <a name="resource" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.resource"></a>
+
+```typescript
+public readonly resource: TerraformResource;
+```
+
+- *Type:* cdktf.TerraformResource
+
+Gets the underlying Terraform resource for use in dependency declarations This allows explicit dependency management between resources.
+
+---
+
+##### `resourceId`<sup>Required</sup> <a name="resourceId" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.resourceId"></a>
+
+```typescript
+public readonly resourceId: string;
+```
+
+- *Type:* string
+
+Gets the full resource ID.
+
+---
+
+##### `tags`<sup>Required</sup> <a name="tags" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.tags"></a>
+
+```typescript
+public readonly tags: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
+
+All tags on this resource (readonly view).
+
+This getter provides convenient access to all tags including those from props
+and those added dynamically via addTag(). Returns a copy to maintain immutability.
+
+---
+
+##### `location`<sup>Optional</sup> <a name="location" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.location"></a>
+
+```typescript
+public readonly location: string;
+```
+
+- *Type:* string
+
+The location of the resource (optional - not all resources have a location) Child resources typically inherit location from their parent.
+
+---
+
+##### `resolvedApiVersion`<sup>Required</sup> <a name="resolvedApiVersion" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.resolvedApiVersion"></a>
+
+```typescript
+public readonly resolvedApiVersion: string;
+```
+
+- *Type:* string
+
+The resolved API version being used for this resource instance.
+
+This is the actual version that will be used for the Azure API call,
+either explicitly specified in props or automatically resolved to
+the latest active version.
+
+---
+
+##### `schema`<sup>Required</sup> <a name="schema" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.schema"></a>
+
+```typescript
+public readonly schema: ApiSchema;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.ApiSchema
+
+The API schema for the resolved version.
+
+Contains the complete schema definition including properties, validation
+rules, and transformation mappings for the resolved API version.
+
+---
+
+##### `versionConfig`<sup>Required</sup> <a name="versionConfig" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.versionConfig"></a>
+
+```typescript
+public readonly versionConfig: VersionConfig;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.VersionConfig
+
+The version configuration for the resolved version.
+
+Contains lifecycle information, breaking changes, and migration metadata
+for the resolved API version.
+
+---
+
+##### `migrationAnalysis`<sup>Optional</sup> <a name="migrationAnalysis" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.migrationAnalysis"></a>
+
+```typescript
+public readonly migrationAnalysis: MigrationAnalysis;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.MigrationAnalysis
+
+Migration analysis results.
+
+Available after construction if migration analysis is enabled and a
+previous version can be determined for comparison.
+
+---
+
+##### `validationResult`<sup>Optional</sup> <a name="validationResult" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.validationResult"></a>
+
+```typescript
+public readonly validationResult: ValidationResult;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.ValidationResult
+
+Validation results for the resource properties.
+
+Available after construction if validation is enabled. Contains detailed
+information about any validation errors or warnings.
+
+---
+
+##### `displayName`<sup>Required</sup> <a name="displayName" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.displayName"></a>
+
+```typescript
+public readonly displayName: string;
+```
+
+- *Type:* string
+
+Get the display name of the policy set definition.
+
+---
+
+##### `idOutput`<sup>Required</sup> <a name="idOutput" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.idOutput"></a>
+
+```typescript
+public readonly idOutput: TerraformOutput;
+```
+
+- *Type:* cdktf.TerraformOutput
+
+---
+
+##### `nameOutput`<sup>Required</sup> <a name="nameOutput" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.nameOutput"></a>
+
+```typescript
+public readonly nameOutput: TerraformOutput;
+```
+
+- *Type:* cdktf.TerraformOutput
+
+---
+
+##### `policyDefinitionCount`<sup>Required</sup> <a name="policyDefinitionCount" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.policyDefinitionCount"></a>
+
+```typescript
+public readonly policyDefinitionCount: number;
+```
+
+- *Type:* number
+
+Get the number of policy definitions in this set.
+
+---
+
+##### `policySetDefinitionId`<sup>Required</sup> <a name="policySetDefinitionId" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.policySetDefinitionId"></a>
+
+```typescript
+public readonly policySetDefinitionId: string;
+```
+
+- *Type:* string
+
+Get the full resource identifier for use in policy assignments Alias for the id property.
+
+---
+
+##### `policySetDefinitionIdOutput`<sup>Required</sup> <a name="policySetDefinitionIdOutput" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.policySetDefinitionIdOutput"></a>
+
+```typescript
+public readonly policySetDefinitionIdOutput: TerraformOutput;
+```
+
+- *Type:* cdktf.TerraformOutput
+
+---
+
+##### `policyType`<sup>Required</sup> <a name="policyType" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.policyType"></a>
+
+```typescript
+public readonly policyType: string;
+```
+
+- *Type:* string
+
+Get the policy type.
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="@microsoft/terraform-cdk-constructs.PolicySetDefinition.property.props"></a>
+
+```typescript
+public readonly props: PolicySetDefinitionProps;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps
+
+The input properties for this Policy Set Definition instance.
+
+---
+
+
+### PolicySetDefinition <a name="PolicySetDefinition" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition"></a>
+
+Unified Azure Policy Set Definition (Initiative) implementation.
+
+This class provides a single, version-aware implementation for managing Azure
+Policy Set Definitions. It automatically handles version resolution, schema validation,
+and property transformation.
+
+Policy Set Definitions allow you to group multiple policy definitions together
+and assign them as a single unit (also known as "Initiatives" in Azure Portal).
+
+Note: Policy set definitions are created at subscription or management group scope.
+They do not have a location property as they are not region-specific.
+
+*Example*
+
+```typescript
+const initiative = new PolicySetDefinition(this, "security-initiative", {
+  displayName: "Security Baseline",
+  scope: "/subscriptions/00000000-0000-0000-0000-000000000000",
+  policyDefinitions: [
+    {
+      policyDefinitionId: "/providers/Microsoft.Authorization/policyDefinitions/abc123",
+      policyDefinitionReferenceId: "auditVMsWithoutExtensions",
+    },
+  ],
+});
+```
+
+
+#### Initializers <a name="Initializers" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.Initializer"></a>
+
+```typescript
+import { azure_policysetdefinition } from '@microsoft/terraform-cdk-constructs'
+
+new azure_policysetdefinition.PolicySetDefinition(scope: Construct, id: string, props: PolicySetDefinitionProps)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | - The scope in which to define this construct. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.Initializer.parameter.id">id</a></code> | <code>string</code> | - The unique identifier for this instance. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.Initializer.parameter.props">props</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps</code> | - Configuration properties for the Policy Set Definition. |
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.Construct
+
+The scope in which to define this construct.
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.Initializer.parameter.id"></a>
+
+- *Type:* string
+
+The unique identifier for this instance.
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.Initializer.parameter.props"></a>
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps
+
+Configuration properties for the Policy Set Definition.
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.addAccess">addAccess</a></code> | Adds an access role assignment for a specified Azure AD object. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.addTag">addTag</a></code> | Adds a tag to this resource. The tag will be included in the Azure resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.analyzeMigrationTo">analyzeMigrationTo</a></code> | Analyzes migration from current version to a target version. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.latestVersion">latestVersion</a></code> | Gets the latest available version for this resource type. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.supportedVersions">supportedVersions</a></code> | Gets all supported versions for this resource type. |
+
+---
+
+##### `toString` <a name="toString" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.toString"></a>
+
+```typescript
+public toString(): string
+```
+
+Returns a string representation of this construct.
+
+##### `addAccess` <a name="addAccess" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.addAccess"></a>
+
+```typescript
+public addAccess(objectId: string, roleDefinitionName: string): void
+```
+
+Adds an access role assignment for a specified Azure AD object.
+
+Note: This method creates role assignments using AZAPI instead of AzureRM provider.
+
+###### `objectId`<sup>Required</sup> <a name="objectId" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.addAccess.parameter.objectId"></a>
+
+- *Type:* string
+
+The unique identifier of the Azure AD object.
+
+---
+
+###### `roleDefinitionName`<sup>Required</sup> <a name="roleDefinitionName" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.addAccess.parameter.roleDefinitionName"></a>
+
+- *Type:* string
+
+The name of the Azure RBAC role to be assigned.
+
+---
+
+##### `addTag` <a name="addTag" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.addTag"></a>
+
+```typescript
+public addTag(key: string, value: string): void
+```
+
+Adds a tag to this resource. The tag will be included in the Azure resource.
+
+This method provides proper immutability by storing tags separately from props.
+Tags added via this method are combined with tags from props and included in
+the deployed Azure resource.
+
+**Important:** In CDK for Terraform, tags should ideally be set during resource
+construction via props. While this method allows adding tags after construction,
+those tags are only included if added before the Terraform configuration is
+synthesized. For best results, add all tags via props or call addTag() in the
+same scope where the resource is created.
+
+###### `key`<sup>Required</sup> <a name="key" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.addTag.parameter.key"></a>
+
+- *Type:* string
+
+The tag key.
+
+---
+
+###### `value`<sup>Required</sup> <a name="value" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.addTag.parameter.value"></a>
+
+- *Type:* string
+
+The tag value.
+
+---
+
+##### `analyzeMigrationTo` <a name="analyzeMigrationTo" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.analyzeMigrationTo"></a>
+
+```typescript
+public analyzeMigrationTo(targetVersion: string): MigrationAnalysis
+```
+
+Analyzes migration from current version to a target version.
+
+This method enables external tools to analyze migration requirements
+between versions for planning and automation purposes.
+
+###### `targetVersion`<sup>Required</sup> <a name="targetVersion" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.analyzeMigrationTo.parameter.targetVersion"></a>
+
+- *Type:* string
+
+The target version to analyze migration to.
+
+---
+
+##### `latestVersion` <a name="latestVersion" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.latestVersion"></a>
+
+```typescript
+public latestVersion(): string
+```
+
+Gets the latest available version for this resource type.
+
+This method provides access to the latest version resolution logic
+for use in subclasses or external tooling.
+
+##### `supportedVersions` <a name="supportedVersions" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.supportedVersions"></a>
+
+```typescript
+public supportedVersions(): string[]
+```
+
+Gets all supported versions for this resource type.
+
+This method provides access to the version registry for use in
+subclasses or external tooling.
+
+#### Static Functions <a name="Static Functions" id="Static Functions"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+
+---
+
+##### `isConstruct` <a name="isConstruct" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.isConstruct"></a>
+
+```typescript
+import { azure_policysetdefinition } from '@microsoft/terraform-cdk-constructs'
+
+azure_policysetdefinition.PolicySetDefinition.isConstruct(x: any)
+```
+
+Checks if `x` is a construct.
+
+Use this method instead of `instanceof` to properly detect `Construct`
+instances, even when the construct library is symlinked.
+
+Explanation: in JavaScript, multiple copies of the `constructs` library on
+disk are seen as independent, completely different libraries. As a
+consequence, the class `Construct` in each copy of the `constructs` library
+is seen as a different class, and an instance of one class will not test as
+`instanceof` the other class. `npm install` will not create installations
+like this, but users may manually symlink construct libraries together or
+use a monorepo tool: in those cases, multiple copies of the `constructs`
+library can be accidentally installed, and `instanceof` will behave
+unpredictably. It is safest to avoid using `instanceof`, and using
+this type-testing method instead.
+
+###### `x`<sup>Required</sup> <a name="x" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.isConstruct.parameter.x"></a>
+
+- *Type:* any
+
+Any object.
+
+---
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.id">id</a></code> | <code>string</code> | The Azure resource ID. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.name">name</a></code> | <code>string</code> | The name of the resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.output">output</a></code> | <code>cdktf.TerraformOutput</code> | Gets the resource as a Terraform output value. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.resource">resource</a></code> | <code>cdktf.TerraformResource</code> | Gets the underlying Terraform resource for use in dependency declarations This allows explicit dependency management between resources. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.resourceId">resourceId</a></code> | <code>string</code> | Gets the full resource ID. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.tags">tags</a></code> | <code>{[ key: string ]: string}</code> | All tags on this resource (readonly view). |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.location">location</a></code> | <code>string</code> | The location of the resource (optional - not all resources have a location) Child resources typically inherit location from their parent. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.resolvedApiVersion">resolvedApiVersion</a></code> | <code>string</code> | The resolved API version being used for this resource instance. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.schema">schema</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.ApiSchema</code> | The API schema for the resolved version. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.versionConfig">versionConfig</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.VersionConfig</code> | The version configuration for the resolved version. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.migrationAnalysis">migrationAnalysis</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.MigrationAnalysis</code> | Migration analysis results. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.validationResult">validationResult</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.ValidationResult</code> | Validation results for the resource properties. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.displayName">displayName</a></code> | <code>string</code> | Get the display name of the policy set definition. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.idOutput">idOutput</a></code> | <code>cdktf.TerraformOutput</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.nameOutput">nameOutput</a></code> | <code>cdktf.TerraformOutput</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.policyDefinitionCount">policyDefinitionCount</a></code> | <code>number</code> | Get the number of policy definitions in this set. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.policySetDefinitionId">policySetDefinitionId</a></code> | <code>string</code> | Get the full resource identifier for use in policy assignments Alias for the id property. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.policySetDefinitionIdOutput">policySetDefinitionIdOutput</a></code> | <code>cdktf.TerraformOutput</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.policyType">policyType</a></code> | <code>string</code> | Get the policy type. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.props">props</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps</code> | The input properties for this Policy Set Definition instance. |
+
+---
+
+##### `node`<sup>Required</sup> <a name="node" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.node"></a>
+
+```typescript
+public readonly node: Node;
+```
+
+- *Type:* constructs.Node
+
+The tree node.
+
+---
+
+##### `id`<sup>Required</sup> <a name="id" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.id"></a>
+
+```typescript
+public readonly id: string;
+```
+
+- *Type:* string
+
+The Azure resource ID.
+
+This property is automatically derived from the underlying Terraform resource.
+Child classes no longer need to implement this property.
+
+---
+
+##### `name`<sup>Required</sup> <a name="name" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* string
+
+The name of the resource.
+
+---
+
+##### `output`<sup>Required</sup> <a name="output" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.output"></a>
+
+```typescript
+public readonly output: TerraformOutput;
+```
+
+- *Type:* cdktf.TerraformOutput
+
+Gets the resource as a Terraform output value.
+
+---
+
+##### `resource`<sup>Required</sup> <a name="resource" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.resource"></a>
+
+```typescript
+public readonly resource: TerraformResource;
+```
+
+- *Type:* cdktf.TerraformResource
+
+Gets the underlying Terraform resource for use in dependency declarations This allows explicit dependency management between resources.
+
+---
+
+##### `resourceId`<sup>Required</sup> <a name="resourceId" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.resourceId"></a>
+
+```typescript
+public readonly resourceId: string;
+```
+
+- *Type:* string
+
+Gets the full resource ID.
+
+---
+
+##### `tags`<sup>Required</sup> <a name="tags" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.tags"></a>
+
+```typescript
+public readonly tags: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
+
+All tags on this resource (readonly view).
+
+This getter provides convenient access to all tags including those from props
+and those added dynamically via addTag(). Returns a copy to maintain immutability.
+
+---
+
+##### `location`<sup>Optional</sup> <a name="location" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.location"></a>
+
+```typescript
+public readonly location: string;
+```
+
+- *Type:* string
+
+The location of the resource (optional - not all resources have a location) Child resources typically inherit location from their parent.
+
+---
+
+##### `resolvedApiVersion`<sup>Required</sup> <a name="resolvedApiVersion" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.resolvedApiVersion"></a>
+
+```typescript
+public readonly resolvedApiVersion: string;
+```
+
+- *Type:* string
+
+The resolved API version being used for this resource instance.
+
+This is the actual version that will be used for the Azure API call,
+either explicitly specified in props or automatically resolved to
+the latest active version.
+
+---
+
+##### `schema`<sup>Required</sup> <a name="schema" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.schema"></a>
+
+```typescript
+public readonly schema: ApiSchema;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.ApiSchema
+
+The API schema for the resolved version.
+
+Contains the complete schema definition including properties, validation
+rules, and transformation mappings for the resolved API version.
+
+---
+
+##### `versionConfig`<sup>Required</sup> <a name="versionConfig" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.versionConfig"></a>
+
+```typescript
+public readonly versionConfig: VersionConfig;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.VersionConfig
+
+The version configuration for the resolved version.
+
+Contains lifecycle information, breaking changes, and migration metadata
+for the resolved API version.
+
+---
+
+##### `migrationAnalysis`<sup>Optional</sup> <a name="migrationAnalysis" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.migrationAnalysis"></a>
+
+```typescript
+public readonly migrationAnalysis: MigrationAnalysis;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.MigrationAnalysis
+
+Migration analysis results.
+
+Available after construction if migration analysis is enabled and a
+previous version can be determined for comparison.
+
+---
+
+##### `validationResult`<sup>Optional</sup> <a name="validationResult" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.validationResult"></a>
+
+```typescript
+public readonly validationResult: ValidationResult;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.ValidationResult
+
+Validation results for the resource properties.
+
+Available after construction if validation is enabled. Contains detailed
+information about any validation errors or warnings.
+
+---
+
+##### `displayName`<sup>Required</sup> <a name="displayName" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.displayName"></a>
+
+```typescript
+public readonly displayName: string;
+```
+
+- *Type:* string
+
+Get the display name of the policy set definition.
+
+---
+
+##### `idOutput`<sup>Required</sup> <a name="idOutput" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.idOutput"></a>
+
+```typescript
+public readonly idOutput: TerraformOutput;
+```
+
+- *Type:* cdktf.TerraformOutput
+
+---
+
+##### `nameOutput`<sup>Required</sup> <a name="nameOutput" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.nameOutput"></a>
+
+```typescript
+public readonly nameOutput: TerraformOutput;
+```
+
+- *Type:* cdktf.TerraformOutput
+
+---
+
+##### `policyDefinitionCount`<sup>Required</sup> <a name="policyDefinitionCount" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.policyDefinitionCount"></a>
+
+```typescript
+public readonly policyDefinitionCount: number;
+```
+
+- *Type:* number
+
+Get the number of policy definitions in this set.
+
+---
+
+##### `policySetDefinitionId`<sup>Required</sup> <a name="policySetDefinitionId" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.policySetDefinitionId"></a>
+
+```typescript
+public readonly policySetDefinitionId: string;
+```
+
+- *Type:* string
+
+Get the full resource identifier for use in policy assignments Alias for the id property.
+
+---
+
+##### `policySetDefinitionIdOutput`<sup>Required</sup> <a name="policySetDefinitionIdOutput" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.policySetDefinitionIdOutput"></a>
+
+```typescript
+public readonly policySetDefinitionIdOutput: TerraformOutput;
+```
+
+- *Type:* cdktf.TerraformOutput
+
+---
+
+##### `policyType`<sup>Required</sup> <a name="policyType" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.policyType"></a>
+
+```typescript
+public readonly policyType: string;
+```
+
+- *Type:* string
+
+Get the policy type.
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinition.property.props"></a>
+
+```typescript
+public readonly props: PolicySetDefinitionProps;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps
+
+The input properties for this Policy Set Definition instance.
 
 ---
 
@@ -109966,6 +113000,1536 @@ SA lifetime in seconds.
 ```
 
 
+### LogAnalyticsWorkspaceBody <a name="LogAnalyticsWorkspaceBody" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceBody"></a>
+
+The resource body interface for Azure Log Analytics Workspace API calls.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceBody.Initializer"></a>
+
+```typescript
+import { LogAnalyticsWorkspaceBody } from '@microsoft/terraform-cdk-constructs'
+
+const logAnalyticsWorkspaceBody: LogAnalyticsWorkspaceBody = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceBody.property.properties">properties</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceBodyProperties</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceBody.property.identity">identity</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceIdentity</code> | *No description.* |
+
+---
+
+##### `properties`<sup>Required</sup> <a name="properties" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceBody.property.properties"></a>
+
+```typescript
+public readonly properties: LogAnalyticsWorkspaceBodyProperties;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceBodyProperties
+
+---
+
+##### `identity`<sup>Optional</sup> <a name="identity" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceBody.property.identity"></a>
+
+```typescript
+public readonly identity: LogAnalyticsWorkspaceIdentity;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceIdentity
+
+---
+
+### LogAnalyticsWorkspaceBody <a name="LogAnalyticsWorkspaceBody" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceBody"></a>
+
+The resource body interface for Azure Log Analytics Workspace API calls.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceBody.Initializer"></a>
+
+```typescript
+import { azure_loganalyticsworkspace } from '@microsoft/terraform-cdk-constructs'
+
+const logAnalyticsWorkspaceBody: azure_loganalyticsworkspace.LogAnalyticsWorkspaceBody = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceBody.property.properties">properties</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceBodyProperties</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceBody.property.identity">identity</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceIdentity</code> | *No description.* |
+
+---
+
+##### `properties`<sup>Required</sup> <a name="properties" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceBody.property.properties"></a>
+
+```typescript
+public readonly properties: LogAnalyticsWorkspaceBodyProperties;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceBodyProperties
+
+---
+
+##### `identity`<sup>Optional</sup> <a name="identity" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceBody.property.identity"></a>
+
+```typescript
+public readonly identity: LogAnalyticsWorkspaceIdentity;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceIdentity
+
+---
+
+### LogAnalyticsWorkspaceBodyProperties <a name="LogAnalyticsWorkspaceBodyProperties" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceBodyProperties"></a>
+
+Properties for the Log Analytics Workspace request body.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceBodyProperties.Initializer"></a>
+
+```typescript
+import { LogAnalyticsWorkspaceBodyProperties } from '@microsoft/terraform-cdk-constructs'
+
+const logAnalyticsWorkspaceBodyProperties: LogAnalyticsWorkspaceBodyProperties = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceBodyProperties.property.defaultDataCollectionRuleResourceId">defaultDataCollectionRuleResourceId</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceBodyProperties.property.features">features</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceFeatures</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceBodyProperties.property.forceCmkForQuery">forceCmkForQuery</a></code> | <code>boolean</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceBodyProperties.property.publicNetworkAccessForIngestion">publicNetworkAccessForIngestion</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceBodyProperties.property.publicNetworkAccessForQuery">publicNetworkAccessForQuery</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceBodyProperties.property.retentionInDays">retentionInDays</a></code> | <code>number</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceBodyProperties.property.sku">sku</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceSku</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceBodyProperties.property.workspaceCapping">workspaceCapping</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceCapping</code> | *No description.* |
+
+---
+
+##### `defaultDataCollectionRuleResourceId`<sup>Optional</sup> <a name="defaultDataCollectionRuleResourceId" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceBodyProperties.property.defaultDataCollectionRuleResourceId"></a>
+
+```typescript
+public readonly defaultDataCollectionRuleResourceId: string;
+```
+
+- *Type:* string
+
+---
+
+##### `features`<sup>Optional</sup> <a name="features" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceBodyProperties.property.features"></a>
+
+```typescript
+public readonly features: LogAnalyticsWorkspaceFeatures;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceFeatures
+
+---
+
+##### `forceCmkForQuery`<sup>Optional</sup> <a name="forceCmkForQuery" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceBodyProperties.property.forceCmkForQuery"></a>
+
+```typescript
+public readonly forceCmkForQuery: boolean;
+```
+
+- *Type:* boolean
+
+---
+
+##### `publicNetworkAccessForIngestion`<sup>Optional</sup> <a name="publicNetworkAccessForIngestion" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceBodyProperties.property.publicNetworkAccessForIngestion"></a>
+
+```typescript
+public readonly publicNetworkAccessForIngestion: string;
+```
+
+- *Type:* string
+
+---
+
+##### `publicNetworkAccessForQuery`<sup>Optional</sup> <a name="publicNetworkAccessForQuery" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceBodyProperties.property.publicNetworkAccessForQuery"></a>
+
+```typescript
+public readonly publicNetworkAccessForQuery: string;
+```
+
+- *Type:* string
+
+---
+
+##### `retentionInDays`<sup>Optional</sup> <a name="retentionInDays" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceBodyProperties.property.retentionInDays"></a>
+
+```typescript
+public readonly retentionInDays: number;
+```
+
+- *Type:* number
+
+---
+
+##### `sku`<sup>Optional</sup> <a name="sku" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceBodyProperties.property.sku"></a>
+
+```typescript
+public readonly sku: LogAnalyticsWorkspaceSku;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceSku
+
+---
+
+##### `workspaceCapping`<sup>Optional</sup> <a name="workspaceCapping" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceBodyProperties.property.workspaceCapping"></a>
+
+```typescript
+public readonly workspaceCapping: LogAnalyticsWorkspaceCapping;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceCapping
+
+---
+
+### LogAnalyticsWorkspaceBodyProperties <a name="LogAnalyticsWorkspaceBodyProperties" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceBodyProperties"></a>
+
+Properties for the Log Analytics Workspace request body.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceBodyProperties.Initializer"></a>
+
+```typescript
+import { azure_loganalyticsworkspace } from '@microsoft/terraform-cdk-constructs'
+
+const logAnalyticsWorkspaceBodyProperties: azure_loganalyticsworkspace.LogAnalyticsWorkspaceBodyProperties = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceBodyProperties.property.defaultDataCollectionRuleResourceId">defaultDataCollectionRuleResourceId</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceBodyProperties.property.features">features</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceFeatures</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceBodyProperties.property.forceCmkForQuery">forceCmkForQuery</a></code> | <code>boolean</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceBodyProperties.property.publicNetworkAccessForIngestion">publicNetworkAccessForIngestion</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceBodyProperties.property.publicNetworkAccessForQuery">publicNetworkAccessForQuery</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceBodyProperties.property.retentionInDays">retentionInDays</a></code> | <code>number</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceBodyProperties.property.sku">sku</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceSku</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceBodyProperties.property.workspaceCapping">workspaceCapping</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceCapping</code> | *No description.* |
+
+---
+
+##### `defaultDataCollectionRuleResourceId`<sup>Optional</sup> <a name="defaultDataCollectionRuleResourceId" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceBodyProperties.property.defaultDataCollectionRuleResourceId"></a>
+
+```typescript
+public readonly defaultDataCollectionRuleResourceId: string;
+```
+
+- *Type:* string
+
+---
+
+##### `features`<sup>Optional</sup> <a name="features" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceBodyProperties.property.features"></a>
+
+```typescript
+public readonly features: LogAnalyticsWorkspaceFeatures;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceFeatures
+
+---
+
+##### `forceCmkForQuery`<sup>Optional</sup> <a name="forceCmkForQuery" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceBodyProperties.property.forceCmkForQuery"></a>
+
+```typescript
+public readonly forceCmkForQuery: boolean;
+```
+
+- *Type:* boolean
+
+---
+
+##### `publicNetworkAccessForIngestion`<sup>Optional</sup> <a name="publicNetworkAccessForIngestion" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceBodyProperties.property.publicNetworkAccessForIngestion"></a>
+
+```typescript
+public readonly publicNetworkAccessForIngestion: string;
+```
+
+- *Type:* string
+
+---
+
+##### `publicNetworkAccessForQuery`<sup>Optional</sup> <a name="publicNetworkAccessForQuery" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceBodyProperties.property.publicNetworkAccessForQuery"></a>
+
+```typescript
+public readonly publicNetworkAccessForQuery: string;
+```
+
+- *Type:* string
+
+---
+
+##### `retentionInDays`<sup>Optional</sup> <a name="retentionInDays" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceBodyProperties.property.retentionInDays"></a>
+
+```typescript
+public readonly retentionInDays: number;
+```
+
+- *Type:* number
+
+---
+
+##### `sku`<sup>Optional</sup> <a name="sku" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceBodyProperties.property.sku"></a>
+
+```typescript
+public readonly sku: LogAnalyticsWorkspaceSku;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceSku
+
+---
+
+##### `workspaceCapping`<sup>Optional</sup> <a name="workspaceCapping" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceBodyProperties.property.workspaceCapping"></a>
+
+```typescript
+public readonly workspaceCapping: LogAnalyticsWorkspaceCapping;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceCapping
+
+---
+
+### LogAnalyticsWorkspaceCapping <a name="LogAnalyticsWorkspaceCapping" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceCapping"></a>
+
+Workspace capping configuration for daily data ingestion limits.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceCapping.Initializer"></a>
+
+```typescript
+import { LogAnalyticsWorkspaceCapping } from '@microsoft/terraform-cdk-constructs'
+
+const logAnalyticsWorkspaceCapping: LogAnalyticsWorkspaceCapping = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceCapping.property.dailyQuotaGb">dailyQuotaGb</a></code> | <code>number</code> | Daily volume cap in GB A value of -1 means no cap. |
+
+---
+
+##### `dailyQuotaGb`<sup>Required</sup> <a name="dailyQuotaGb" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceCapping.property.dailyQuotaGb"></a>
+
+```typescript
+public readonly dailyQuotaGb: number;
+```
+
+- *Type:* number
+
+Daily volume cap in GB A value of -1 means no cap.
+
+---
+
+### LogAnalyticsWorkspaceCapping <a name="LogAnalyticsWorkspaceCapping" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceCapping"></a>
+
+Workspace capping configuration for daily data ingestion limits.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceCapping.Initializer"></a>
+
+```typescript
+import { azure_loganalyticsworkspace } from '@microsoft/terraform-cdk-constructs'
+
+const logAnalyticsWorkspaceCapping: azure_loganalyticsworkspace.LogAnalyticsWorkspaceCapping = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceCapping.property.dailyQuotaGb">dailyQuotaGb</a></code> | <code>number</code> | Daily volume cap in GB A value of -1 means no cap. |
+
+---
+
+##### `dailyQuotaGb`<sup>Required</sup> <a name="dailyQuotaGb" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceCapping.property.dailyQuotaGb"></a>
+
+```typescript
+public readonly dailyQuotaGb: number;
+```
+
+- *Type:* number
+
+Daily volume cap in GB A value of -1 means no cap.
+
+---
+
+### LogAnalyticsWorkspaceFeatures <a name="LogAnalyticsWorkspaceFeatures" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceFeatures"></a>
+
+Workspace features configuration.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceFeatures.Initializer"></a>
+
+```typescript
+import { LogAnalyticsWorkspaceFeatures } from '@microsoft/terraform-cdk-constructs'
+
+const logAnalyticsWorkspaceFeatures: LogAnalyticsWorkspaceFeatures = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceFeatures.property.disableLocalAuth">disableLocalAuth</a></code> | <code>boolean</code> | Flag indicating whether log access using AADIAM is disabled. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceFeatures.property.enableDataExport">enableDataExport</a></code> | <code>boolean</code> | Flag indicating whether data export is enabled. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceFeatures.property.enableLogAccessUsingOnlyResourcePermissions">enableLogAccessUsingOnlyResourcePermissions</a></code> | <code>boolean</code> | Flag indicating whether cluster resource permissions are enabled. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceFeatures.property.immediatePurgeDataOn30Days">immediatePurgeDataOn30Days</a></code> | <code>boolean</code> | Flag indicating whether data should be immediately purged after 30 days instead of the configured retention period. |
+
+---
+
+##### `disableLocalAuth`<sup>Optional</sup> <a name="disableLocalAuth" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceFeatures.property.disableLocalAuth"></a>
+
+```typescript
+public readonly disableLocalAuth: boolean;
+```
+
+- *Type:* boolean
+
+Flag indicating whether log access using AADIAM is disabled.
+
+---
+
+##### `enableDataExport`<sup>Optional</sup> <a name="enableDataExport" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceFeatures.property.enableDataExport"></a>
+
+```typescript
+public readonly enableDataExport: boolean;
+```
+
+- *Type:* boolean
+
+Flag indicating whether data export is enabled.
+
+---
+
+##### `enableLogAccessUsingOnlyResourcePermissions`<sup>Optional</sup> <a name="enableLogAccessUsingOnlyResourcePermissions" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceFeatures.property.enableLogAccessUsingOnlyResourcePermissions"></a>
+
+```typescript
+public readonly enableLogAccessUsingOnlyResourcePermissions: boolean;
+```
+
+- *Type:* boolean
+
+Flag indicating whether cluster resource permissions are enabled.
+
+---
+
+##### `immediatePurgeDataOn30Days`<sup>Optional</sup> <a name="immediatePurgeDataOn30Days" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceFeatures.property.immediatePurgeDataOn30Days"></a>
+
+```typescript
+public readonly immediatePurgeDataOn30Days: boolean;
+```
+
+- *Type:* boolean
+
+Flag indicating whether data should be immediately purged after 30 days instead of the configured retention period.
+
+---
+
+### LogAnalyticsWorkspaceFeatures <a name="LogAnalyticsWorkspaceFeatures" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceFeatures"></a>
+
+Workspace features configuration.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceFeatures.Initializer"></a>
+
+```typescript
+import { azure_loganalyticsworkspace } from '@microsoft/terraform-cdk-constructs'
+
+const logAnalyticsWorkspaceFeatures: azure_loganalyticsworkspace.LogAnalyticsWorkspaceFeatures = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceFeatures.property.disableLocalAuth">disableLocalAuth</a></code> | <code>boolean</code> | Flag indicating whether log access using AADIAM is disabled. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceFeatures.property.enableDataExport">enableDataExport</a></code> | <code>boolean</code> | Flag indicating whether data export is enabled. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceFeatures.property.enableLogAccessUsingOnlyResourcePermissions">enableLogAccessUsingOnlyResourcePermissions</a></code> | <code>boolean</code> | Flag indicating whether cluster resource permissions are enabled. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceFeatures.property.immediatePurgeDataOn30Days">immediatePurgeDataOn30Days</a></code> | <code>boolean</code> | Flag indicating whether data should be immediately purged after 30 days instead of the configured retention period. |
+
+---
+
+##### `disableLocalAuth`<sup>Optional</sup> <a name="disableLocalAuth" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceFeatures.property.disableLocalAuth"></a>
+
+```typescript
+public readonly disableLocalAuth: boolean;
+```
+
+- *Type:* boolean
+
+Flag indicating whether log access using AADIAM is disabled.
+
+---
+
+##### `enableDataExport`<sup>Optional</sup> <a name="enableDataExport" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceFeatures.property.enableDataExport"></a>
+
+```typescript
+public readonly enableDataExport: boolean;
+```
+
+- *Type:* boolean
+
+Flag indicating whether data export is enabled.
+
+---
+
+##### `enableLogAccessUsingOnlyResourcePermissions`<sup>Optional</sup> <a name="enableLogAccessUsingOnlyResourcePermissions" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceFeatures.property.enableLogAccessUsingOnlyResourcePermissions"></a>
+
+```typescript
+public readonly enableLogAccessUsingOnlyResourcePermissions: boolean;
+```
+
+- *Type:* boolean
+
+Flag indicating whether cluster resource permissions are enabled.
+
+---
+
+##### `immediatePurgeDataOn30Days`<sup>Optional</sup> <a name="immediatePurgeDataOn30Days" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceFeatures.property.immediatePurgeDataOn30Days"></a>
+
+```typescript
+public readonly immediatePurgeDataOn30Days: boolean;
+```
+
+- *Type:* boolean
+
+Flag indicating whether data should be immediately purged after 30 days instead of the configured retention period.
+
+---
+
+### LogAnalyticsWorkspaceIdentity <a name="LogAnalyticsWorkspaceIdentity" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceIdentity"></a>
+
+Managed identity configuration for the workspace.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceIdentity.Initializer"></a>
+
+```typescript
+import { LogAnalyticsWorkspaceIdentity } from '@microsoft/terraform-cdk-constructs'
+
+const logAnalyticsWorkspaceIdentity: LogAnalyticsWorkspaceIdentity = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceIdentity.property.type">type</a></code> | <code>string</code> | Type of managed identity. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceIdentity.property.userAssignedIdentities">userAssignedIdentities</a></code> | <code>{[ key: string ]: any}</code> | User-assigned identity resource IDs Required when type includes UserAssigned. |
+
+---
+
+##### `type`<sup>Required</sup> <a name="type" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceIdentity.property.type"></a>
+
+```typescript
+public readonly type: string;
+```
+
+- *Type:* string
+
+Type of managed identity.
+
+---
+
+##### `userAssignedIdentities`<sup>Optional</sup> <a name="userAssignedIdentities" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceIdentity.property.userAssignedIdentities"></a>
+
+```typescript
+public readonly userAssignedIdentities: {[ key: string ]: any};
+```
+
+- *Type:* {[ key: string ]: any}
+
+User-assigned identity resource IDs Required when type includes UserAssigned.
+
+---
+
+### LogAnalyticsWorkspaceIdentity <a name="LogAnalyticsWorkspaceIdentity" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceIdentity"></a>
+
+Managed identity configuration for the workspace.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceIdentity.Initializer"></a>
+
+```typescript
+import { azure_loganalyticsworkspace } from '@microsoft/terraform-cdk-constructs'
+
+const logAnalyticsWorkspaceIdentity: azure_loganalyticsworkspace.LogAnalyticsWorkspaceIdentity = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceIdentity.property.type">type</a></code> | <code>string</code> | Type of managed identity. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceIdentity.property.userAssignedIdentities">userAssignedIdentities</a></code> | <code>{[ key: string ]: any}</code> | User-assigned identity resource IDs Required when type includes UserAssigned. |
+
+---
+
+##### `type`<sup>Required</sup> <a name="type" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceIdentity.property.type"></a>
+
+```typescript
+public readonly type: string;
+```
+
+- *Type:* string
+
+Type of managed identity.
+
+---
+
+##### `userAssignedIdentities`<sup>Optional</sup> <a name="userAssignedIdentities" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceIdentity.property.userAssignedIdentities"></a>
+
+```typescript
+public readonly userAssignedIdentities: {[ key: string ]: any};
+```
+
+- *Type:* {[ key: string ]: any}
+
+User-assigned identity resource IDs Required when type includes UserAssigned.
+
+---
+
+### LogAnalyticsWorkspaceProps <a name="LogAnalyticsWorkspaceProps" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps"></a>
+
+Properties for the unified Azure Log Analytics Workspace.
+
+Extends AzapiResourceProps with Log Analytics Workspace specific properties
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.Initializer"></a>
+
+```typescript
+import { LogAnalyticsWorkspaceProps } from '@microsoft/terraform-cdk-constructs'
+
+const logAnalyticsWorkspaceProps: LogAnalyticsWorkspaceProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.connection">connection</a></code> | <code>cdktf.SSHProvisionerConnection \| cdktf.WinrmProvisionerConnection</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.count">count</a></code> | <code>number \| cdktf.TerraformCount</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.dependsOn">dependsOn</a></code> | <code>cdktf.ITerraformDependable[]</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.forEach">forEach</a></code> | <code>cdktf.ITerraformIterator</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.lifecycle">lifecycle</a></code> | <code>cdktf.TerraformResourceLifecycle</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.provider">provider</a></code> | <code>cdktf.TerraformProvider</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.provisioners">provisioners</a></code> | <code>cdktf.FileProvisioner \| cdktf.LocalExecProvisioner \| cdktf.RemoteExecProvisioner[]</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.apiVersion">apiVersion</a></code> | <code>string</code> | Explicit API version to use for this resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.enableMigrationAnalysis">enableMigrationAnalysis</a></code> | <code>boolean</code> | Whether to enable migration analysis warnings. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.enableTransformation">enableTransformation</a></code> | <code>boolean</code> | Whether to apply property transformations automatically. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.enableValidation">enableValidation</a></code> | <code>boolean</code> | Whether to validate properties against the schema. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.location">location</a></code> | <code>string</code> | The location where the resource should be created. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.monitoring">monitoring</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.MonitoringConfig</code> | Monitoring configuration for this resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.name">name</a></code> | <code>string</code> | The name of the resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.tags">tags</a></code> | <code>{[ key: string ]: string}</code> | Tags to apply to the resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.resourceGroupId">resourceGroupId</a></code> | <code>string</code> | Resource Group ID where the workspace will be created The workspace will be created as a child of this resource group. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.defaultDataCollectionRuleResourceId">defaultDataCollectionRuleResourceId</a></code> | <code>string</code> | Resource ID of the default Data Collection Rule. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.features">features</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceFeatures</code> | Workspace features configuration. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.forceCmkForQuery">forceCmkForQuery</a></code> | <code>boolean</code> | Whether customer-managed keys are required for saved searches and alerts. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.identity">identity</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceIdentity</code> | Managed identity configuration for the workspace. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.publicNetworkAccessForIngestion">publicNetworkAccessForIngestion</a></code> | <code>string</code> | Public network access for data ingestion. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.publicNetworkAccessForQuery">publicNetworkAccessForQuery</a></code> | <code>string</code> | Public network access for querying data. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.retentionInDays">retentionInDays</a></code> | <code>number</code> | Data retention period in days. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.sku">sku</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceSku</code> | SKU configuration for the workspace. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.workspaceCapping">workspaceCapping</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceCapping</code> | Daily volume cap for data ingestion. |
+
+---
+
+##### `connection`<sup>Optional</sup> <a name="connection" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.connection"></a>
+
+```typescript
+public readonly connection: SSHProvisionerConnection | WinrmProvisionerConnection;
+```
+
+- *Type:* cdktf.SSHProvisionerConnection | cdktf.WinrmProvisionerConnection
+
+---
+
+##### `count`<sup>Optional</sup> <a name="count" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.count"></a>
+
+```typescript
+public readonly count: number | TerraformCount;
+```
+
+- *Type:* number | cdktf.TerraformCount
+
+---
+
+##### `dependsOn`<sup>Optional</sup> <a name="dependsOn" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.dependsOn"></a>
+
+```typescript
+public readonly dependsOn: ITerraformDependable[];
+```
+
+- *Type:* cdktf.ITerraformDependable[]
+
+---
+
+##### `forEach`<sup>Optional</sup> <a name="forEach" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.forEach"></a>
+
+```typescript
+public readonly forEach: ITerraformIterator;
+```
+
+- *Type:* cdktf.ITerraformIterator
+
+---
+
+##### `lifecycle`<sup>Optional</sup> <a name="lifecycle" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.lifecycle"></a>
+
+```typescript
+public readonly lifecycle: TerraformResourceLifecycle;
+```
+
+- *Type:* cdktf.TerraformResourceLifecycle
+
+---
+
+##### `provider`<sup>Optional</sup> <a name="provider" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.provider"></a>
+
+```typescript
+public readonly provider: TerraformProvider;
+```
+
+- *Type:* cdktf.TerraformProvider
+
+---
+
+##### `provisioners`<sup>Optional</sup> <a name="provisioners" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.provisioners"></a>
+
+```typescript
+public readonly provisioners: (FileProvisioner | LocalExecProvisioner | RemoteExecProvisioner)[];
+```
+
+- *Type:* cdktf.FileProvisioner | cdktf.LocalExecProvisioner | cdktf.RemoteExecProvisioner[]
+
+---
+
+##### `apiVersion`<sup>Optional</sup> <a name="apiVersion" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.apiVersion"></a>
+
+```typescript
+public readonly apiVersion: string;
+```
+
+- *Type:* string
+- *Default:* Latest active version from ApiVersionManager
+
+Explicit API version to use for this resource.
+
+If not specified, the latest active version will be automatically resolved.
+Use this for version pinning when stability is required over latest features.
+
+---
+
+*Example*
+
+```typescript
+"2024-11-01"
+```
+
+
+##### `enableMigrationAnalysis`<sup>Optional</sup> <a name="enableMigrationAnalysis" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.enableMigrationAnalysis"></a>
+
+```typescript
+public readonly enableMigrationAnalysis: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Whether to enable migration analysis warnings.
+
+When true, the framework will analyze the current version for deprecation
+status and provide migration recommendations in the deployment output.
+
+---
+
+##### `enableTransformation`<sup>Optional</sup> <a name="enableTransformation" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.enableTransformation"></a>
+
+```typescript
+public readonly enableTransformation: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Whether to apply property transformations automatically.
+
+When true, properties will be automatically transformed according to the
+target schema's transformation rules. This enables backward compatibility.
+
+---
+
+##### `enableValidation`<sup>Optional</sup> <a name="enableValidation" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.enableValidation"></a>
+
+```typescript
+public readonly enableValidation: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Whether to validate properties against the schema.
+
+When true, all properties will be validated against the API schema before
+resource creation. Validation errors will cause deployment failures.
+
+---
+
+##### `location`<sup>Optional</sup> <a name="location" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.location"></a>
+
+```typescript
+public readonly location: string;
+```
+
+- *Type:* string
+- *Default:* Varies by resource type - see specific resource documentation
+
+The location where the resource should be created.
+
+---
+
+*Example*
+
+```typescript
+// Child resource (Subnet) - do not set location
+// location: undefined (inherited from parent Virtual Network)
+```
+
+
+##### `monitoring`<sup>Optional</sup> <a name="monitoring" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.monitoring"></a>
+
+```typescript
+public readonly monitoring: MonitoringConfig;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.MonitoringConfig
+
+Monitoring configuration for this resource.
+
+Enables integrated monitoring with diagnostic settings, metric alerts,
+and activity log alerts. All monitoring is optional and disabled by default.
+
+---
+
+*Example*
+
+```typescript
+monitoring: {
+  enabled: true,
+  diagnosticSettings: {
+    workspaceId: logAnalytics.id,
+    metrics: ['AllMetrics'],
+    logs: ['AuditLogs']
+  },
+  metricAlerts: [{
+    name: 'high-cpu-alert',
+    severity: 2,
+    scopes: [], // Automatically set to this resource
+    criteria: { ... },
+    actions: [{ actionGroupId: actionGroup.id }]
+  }]
+}
+```
+
+
+##### `name`<sup>Optional</sup> <a name="name" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* string
+
+The name of the resource.
+
+---
+
+##### `tags`<sup>Optional</sup> <a name="tags" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.tags"></a>
+
+```typescript
+public readonly tags: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
+
+Tags to apply to the resource.
+
+---
+
+##### `resourceGroupId`<sup>Required</sup> <a name="resourceGroupId" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.resourceGroupId"></a>
+
+```typescript
+public readonly resourceGroupId: string;
+```
+
+- *Type:* string
+
+Resource Group ID where the workspace will be created The workspace will be created as a child of this resource group.
+
+---
+
+##### `defaultDataCollectionRuleResourceId`<sup>Optional</sup> <a name="defaultDataCollectionRuleResourceId" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.defaultDataCollectionRuleResourceId"></a>
+
+```typescript
+public readonly defaultDataCollectionRuleResourceId: string;
+```
+
+- *Type:* string
+
+Resource ID of the default Data Collection Rule.
+
+Associates a default DCR with the workspace for data collection.
+Only available in API version 2023-09-01 and later.
+
+---
+
+##### `features`<sup>Optional</sup> <a name="features" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.features"></a>
+
+```typescript
+public readonly features: LogAnalyticsWorkspaceFeatures;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceFeatures
+
+Workspace features configuration.
+
+Enables or disables specific workspace features like data export,
+immediate purge, and local authentication.
+
+---
+
+##### `forceCmkForQuery`<sup>Optional</sup> <a name="forceCmkForQuery" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.forceCmkForQuery"></a>
+
+```typescript
+public readonly forceCmkForQuery: boolean;
+```
+
+- *Type:* boolean
+
+Whether customer-managed keys are required for saved searches and alerts.
+
+When enabled, all saved searches and alerts must use customer-managed keys.
+
+---
+
+##### `identity`<sup>Optional</sup> <a name="identity" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.identity"></a>
+
+```typescript
+public readonly identity: LogAnalyticsWorkspaceIdentity;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceIdentity
+
+Managed identity configuration for the workspace.
+
+Enables managed identity authentication for the workspace.
+
+---
+
+##### `publicNetworkAccessForIngestion`<sup>Optional</sup> <a name="publicNetworkAccessForIngestion" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.publicNetworkAccessForIngestion"></a>
+
+```typescript
+public readonly publicNetworkAccessForIngestion: string;
+```
+
+- *Type:* string
+- *Default:* "Enabled"
+
+Public network access for data ingestion.
+
+Controls whether data can be ingested over the public internet.
+
+---
+
+##### `publicNetworkAccessForQuery`<sup>Optional</sup> <a name="publicNetworkAccessForQuery" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.publicNetworkAccessForQuery"></a>
+
+```typescript
+public readonly publicNetworkAccessForQuery: string;
+```
+
+- *Type:* string
+- *Default:* "Enabled"
+
+Public network access for querying data.
+
+Controls whether queries can be executed over the public internet.
+
+---
+
+##### `retentionInDays`<sup>Optional</sup> <a name="retentionInDays" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.retentionInDays"></a>
+
+```typescript
+public readonly retentionInDays: number;
+```
+
+- *Type:* number
+- *Default:* 30
+
+Data retention period in days.
+
+Values between 30 and 730 are supported for pay-as-you-go pricing.
+Free tier is limited to 7 days.
+
+---
+
+##### `sku`<sup>Optional</sup> <a name="sku" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.sku"></a>
+
+```typescript
+public readonly sku: LogAnalyticsWorkspaceSku;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceSku
+- *Default:* { name: "PerGB2018" }
+
+SKU configuration for the workspace.
+
+Determines pricing tier and capabilities of the workspace.
+
+---
+
+##### `workspaceCapping`<sup>Optional</sup> <a name="workspaceCapping" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceProps.property.workspaceCapping"></a>
+
+```typescript
+public readonly workspaceCapping: LogAnalyticsWorkspaceCapping;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceCapping
+
+Daily volume cap for data ingestion.
+
+When the daily cap is reached, data ingestion stops until the next day.
+A value of dailyQuotaGb: -1 means no cap.
+
+---
+
+### LogAnalyticsWorkspaceProps <a name="LogAnalyticsWorkspaceProps" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps"></a>
+
+Properties for the unified Azure Log Analytics Workspace.
+
+Extends AzapiResourceProps with Log Analytics Workspace specific properties
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.Initializer"></a>
+
+```typescript
+import { azure_loganalyticsworkspace } from '@microsoft/terraform-cdk-constructs'
+
+const logAnalyticsWorkspaceProps: azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.connection">connection</a></code> | <code>cdktf.SSHProvisionerConnection \| cdktf.WinrmProvisionerConnection</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.count">count</a></code> | <code>number \| cdktf.TerraformCount</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.dependsOn">dependsOn</a></code> | <code>cdktf.ITerraformDependable[]</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.forEach">forEach</a></code> | <code>cdktf.ITerraformIterator</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.lifecycle">lifecycle</a></code> | <code>cdktf.TerraformResourceLifecycle</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.provider">provider</a></code> | <code>cdktf.TerraformProvider</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.provisioners">provisioners</a></code> | <code>cdktf.FileProvisioner \| cdktf.LocalExecProvisioner \| cdktf.RemoteExecProvisioner[]</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.apiVersion">apiVersion</a></code> | <code>string</code> | Explicit API version to use for this resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.enableMigrationAnalysis">enableMigrationAnalysis</a></code> | <code>boolean</code> | Whether to enable migration analysis warnings. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.enableTransformation">enableTransformation</a></code> | <code>boolean</code> | Whether to apply property transformations automatically. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.enableValidation">enableValidation</a></code> | <code>boolean</code> | Whether to validate properties against the schema. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.location">location</a></code> | <code>string</code> | The location where the resource should be created. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.monitoring">monitoring</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.MonitoringConfig</code> | Monitoring configuration for this resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.name">name</a></code> | <code>string</code> | The name of the resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.tags">tags</a></code> | <code>{[ key: string ]: string}</code> | Tags to apply to the resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.resourceGroupId">resourceGroupId</a></code> | <code>string</code> | Resource Group ID where the workspace will be created The workspace will be created as a child of this resource group. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.defaultDataCollectionRuleResourceId">defaultDataCollectionRuleResourceId</a></code> | <code>string</code> | Resource ID of the default Data Collection Rule. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.features">features</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceFeatures</code> | Workspace features configuration. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.forceCmkForQuery">forceCmkForQuery</a></code> | <code>boolean</code> | Whether customer-managed keys are required for saved searches and alerts. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.identity">identity</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceIdentity</code> | Managed identity configuration for the workspace. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.publicNetworkAccessForIngestion">publicNetworkAccessForIngestion</a></code> | <code>string</code> | Public network access for data ingestion. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.publicNetworkAccessForQuery">publicNetworkAccessForQuery</a></code> | <code>string</code> | Public network access for querying data. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.retentionInDays">retentionInDays</a></code> | <code>number</code> | Data retention period in days. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.sku">sku</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceSku</code> | SKU configuration for the workspace. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.workspaceCapping">workspaceCapping</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceCapping</code> | Daily volume cap for data ingestion. |
+
+---
+
+##### `connection`<sup>Optional</sup> <a name="connection" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.connection"></a>
+
+```typescript
+public readonly connection: SSHProvisionerConnection | WinrmProvisionerConnection;
+```
+
+- *Type:* cdktf.SSHProvisionerConnection | cdktf.WinrmProvisionerConnection
+
+---
+
+##### `count`<sup>Optional</sup> <a name="count" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.count"></a>
+
+```typescript
+public readonly count: number | TerraformCount;
+```
+
+- *Type:* number | cdktf.TerraformCount
+
+---
+
+##### `dependsOn`<sup>Optional</sup> <a name="dependsOn" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.dependsOn"></a>
+
+```typescript
+public readonly dependsOn: ITerraformDependable[];
+```
+
+- *Type:* cdktf.ITerraformDependable[]
+
+---
+
+##### `forEach`<sup>Optional</sup> <a name="forEach" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.forEach"></a>
+
+```typescript
+public readonly forEach: ITerraformIterator;
+```
+
+- *Type:* cdktf.ITerraformIterator
+
+---
+
+##### `lifecycle`<sup>Optional</sup> <a name="lifecycle" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.lifecycle"></a>
+
+```typescript
+public readonly lifecycle: TerraformResourceLifecycle;
+```
+
+- *Type:* cdktf.TerraformResourceLifecycle
+
+---
+
+##### `provider`<sup>Optional</sup> <a name="provider" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.provider"></a>
+
+```typescript
+public readonly provider: TerraformProvider;
+```
+
+- *Type:* cdktf.TerraformProvider
+
+---
+
+##### `provisioners`<sup>Optional</sup> <a name="provisioners" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.provisioners"></a>
+
+```typescript
+public readonly provisioners: (FileProvisioner | LocalExecProvisioner | RemoteExecProvisioner)[];
+```
+
+- *Type:* cdktf.FileProvisioner | cdktf.LocalExecProvisioner | cdktf.RemoteExecProvisioner[]
+
+---
+
+##### `apiVersion`<sup>Optional</sup> <a name="apiVersion" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.apiVersion"></a>
+
+```typescript
+public readonly apiVersion: string;
+```
+
+- *Type:* string
+- *Default:* Latest active version from ApiVersionManager
+
+Explicit API version to use for this resource.
+
+If not specified, the latest active version will be automatically resolved.
+Use this for version pinning when stability is required over latest features.
+
+---
+
+*Example*
+
+```typescript
+"2024-11-01"
+```
+
+
+##### `enableMigrationAnalysis`<sup>Optional</sup> <a name="enableMigrationAnalysis" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.enableMigrationAnalysis"></a>
+
+```typescript
+public readonly enableMigrationAnalysis: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Whether to enable migration analysis warnings.
+
+When true, the framework will analyze the current version for deprecation
+status and provide migration recommendations in the deployment output.
+
+---
+
+##### `enableTransformation`<sup>Optional</sup> <a name="enableTransformation" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.enableTransformation"></a>
+
+```typescript
+public readonly enableTransformation: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Whether to apply property transformations automatically.
+
+When true, properties will be automatically transformed according to the
+target schema's transformation rules. This enables backward compatibility.
+
+---
+
+##### `enableValidation`<sup>Optional</sup> <a name="enableValidation" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.enableValidation"></a>
+
+```typescript
+public readonly enableValidation: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Whether to validate properties against the schema.
+
+When true, all properties will be validated against the API schema before
+resource creation. Validation errors will cause deployment failures.
+
+---
+
+##### `location`<sup>Optional</sup> <a name="location" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.location"></a>
+
+```typescript
+public readonly location: string;
+```
+
+- *Type:* string
+- *Default:* Varies by resource type - see specific resource documentation
+
+The location where the resource should be created.
+
+---
+
+*Example*
+
+```typescript
+// Child resource (Subnet) - do not set location
+// location: undefined (inherited from parent Virtual Network)
+```
+
+
+##### `monitoring`<sup>Optional</sup> <a name="monitoring" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.monitoring"></a>
+
+```typescript
+public readonly monitoring: MonitoringConfig;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.MonitoringConfig
+
+Monitoring configuration for this resource.
+
+Enables integrated monitoring with diagnostic settings, metric alerts,
+and activity log alerts. All monitoring is optional and disabled by default.
+
+---
+
+*Example*
+
+```typescript
+monitoring: {
+  enabled: true,
+  diagnosticSettings: {
+    workspaceId: logAnalytics.id,
+    metrics: ['AllMetrics'],
+    logs: ['AuditLogs']
+  },
+  metricAlerts: [{
+    name: 'high-cpu-alert',
+    severity: 2,
+    scopes: [], // Automatically set to this resource
+    criteria: { ... },
+    actions: [{ actionGroupId: actionGroup.id }]
+  }]
+}
+```
+
+
+##### `name`<sup>Optional</sup> <a name="name" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* string
+
+The name of the resource.
+
+---
+
+##### `tags`<sup>Optional</sup> <a name="tags" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.tags"></a>
+
+```typescript
+public readonly tags: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
+
+Tags to apply to the resource.
+
+---
+
+##### `resourceGroupId`<sup>Required</sup> <a name="resourceGroupId" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.resourceGroupId"></a>
+
+```typescript
+public readonly resourceGroupId: string;
+```
+
+- *Type:* string
+
+Resource Group ID where the workspace will be created The workspace will be created as a child of this resource group.
+
+---
+
+##### `defaultDataCollectionRuleResourceId`<sup>Optional</sup> <a name="defaultDataCollectionRuleResourceId" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.defaultDataCollectionRuleResourceId"></a>
+
+```typescript
+public readonly defaultDataCollectionRuleResourceId: string;
+```
+
+- *Type:* string
+
+Resource ID of the default Data Collection Rule.
+
+Associates a default DCR with the workspace for data collection.
+Only available in API version 2023-09-01 and later.
+
+---
+
+##### `features`<sup>Optional</sup> <a name="features" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.features"></a>
+
+```typescript
+public readonly features: LogAnalyticsWorkspaceFeatures;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceFeatures
+
+Workspace features configuration.
+
+Enables or disables specific workspace features like data export,
+immediate purge, and local authentication.
+
+---
+
+##### `forceCmkForQuery`<sup>Optional</sup> <a name="forceCmkForQuery" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.forceCmkForQuery"></a>
+
+```typescript
+public readonly forceCmkForQuery: boolean;
+```
+
+- *Type:* boolean
+
+Whether customer-managed keys are required for saved searches and alerts.
+
+When enabled, all saved searches and alerts must use customer-managed keys.
+
+---
+
+##### `identity`<sup>Optional</sup> <a name="identity" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.identity"></a>
+
+```typescript
+public readonly identity: LogAnalyticsWorkspaceIdentity;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceIdentity
+
+Managed identity configuration for the workspace.
+
+Enables managed identity authentication for the workspace.
+
+---
+
+##### `publicNetworkAccessForIngestion`<sup>Optional</sup> <a name="publicNetworkAccessForIngestion" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.publicNetworkAccessForIngestion"></a>
+
+```typescript
+public readonly publicNetworkAccessForIngestion: string;
+```
+
+- *Type:* string
+- *Default:* "Enabled"
+
+Public network access for data ingestion.
+
+Controls whether data can be ingested over the public internet.
+
+---
+
+##### `publicNetworkAccessForQuery`<sup>Optional</sup> <a name="publicNetworkAccessForQuery" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.publicNetworkAccessForQuery"></a>
+
+```typescript
+public readonly publicNetworkAccessForQuery: string;
+```
+
+- *Type:* string
+- *Default:* "Enabled"
+
+Public network access for querying data.
+
+Controls whether queries can be executed over the public internet.
+
+---
+
+##### `retentionInDays`<sup>Optional</sup> <a name="retentionInDays" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.retentionInDays"></a>
+
+```typescript
+public readonly retentionInDays: number;
+```
+
+- *Type:* number
+- *Default:* 30
+
+Data retention period in days.
+
+Values between 30 and 730 are supported for pay-as-you-go pricing.
+Free tier is limited to 7 days.
+
+---
+
+##### `sku`<sup>Optional</sup> <a name="sku" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.sku"></a>
+
+```typescript
+public readonly sku: LogAnalyticsWorkspaceSku;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceSku
+- *Default:* { name: "PerGB2018" }
+
+SKU configuration for the workspace.
+
+Determines pricing tier and capabilities of the workspace.
+
+---
+
+##### `workspaceCapping`<sup>Optional</sup> <a name="workspaceCapping" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceProps.property.workspaceCapping"></a>
+
+```typescript
+public readonly workspaceCapping: LogAnalyticsWorkspaceCapping;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceCapping
+
+Daily volume cap for data ingestion.
+
+When the daily cap is reached, data ingestion stops until the next day.
+A value of dailyQuotaGb: -1 means no cap.
+
+---
+
+### LogAnalyticsWorkspaceSku <a name="LogAnalyticsWorkspaceSku" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceSku"></a>
+
+SKU configuration for Log Analytics Workspace.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceSku.Initializer"></a>
+
+```typescript
+import { LogAnalyticsWorkspaceSku } from '@microsoft/terraform-cdk-constructs'
+
+const logAnalyticsWorkspaceSku: LogAnalyticsWorkspaceSku = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceSku.property.name">name</a></code> | <code>string</code> | SKU name for the Log Analytics Workspace. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceSku.property.capacityReservationLevel">capacityReservationLevel</a></code> | <code>number</code> | Capacity reservation level in GB per day Only applicable when SKU name is "CapacityReservation" Valid values: 100, 200, 300, 400, 500, 1000, 2000, 5000. |
+
+---
+
+##### `name`<sup>Required</sup> <a name="name" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceSku.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* string
+- *Default:* "PerGB2018"
+
+SKU name for the Log Analytics Workspace.
+
+Available options:
+- "Free" - Free tier (limited to 500MB/day, 7 day retention)
+- "Standard" - Standard tier (legacy)
+- "Premium" - Premium tier (legacy)
+- "PerNode" - Per node pricing (legacy, for OMS customers)
+- "PerGB2018" - Pay-as-you-go pricing based on data ingestion
+- "Standalone" - Standalone tier (legacy)
+- "CapacityReservation" - Commitment tier with reserved capacity
+
+---
+
+##### `capacityReservationLevel`<sup>Optional</sup> <a name="capacityReservationLevel" id="@microsoft/terraform-cdk-constructs.LogAnalyticsWorkspaceSku.property.capacityReservationLevel"></a>
+
+```typescript
+public readonly capacityReservationLevel: number;
+```
+
+- *Type:* number
+
+Capacity reservation level in GB per day Only applicable when SKU name is "CapacityReservation" Valid values: 100, 200, 300, 400, 500, 1000, 2000, 5000.
+
+---
+
+### LogAnalyticsWorkspaceSku <a name="LogAnalyticsWorkspaceSku" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceSku"></a>
+
+SKU configuration for Log Analytics Workspace.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceSku.Initializer"></a>
+
+```typescript
+import { azure_loganalyticsworkspace } from '@microsoft/terraform-cdk-constructs'
+
+const logAnalyticsWorkspaceSku: azure_loganalyticsworkspace.LogAnalyticsWorkspaceSku = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceSku.property.name">name</a></code> | <code>string</code> | SKU name for the Log Analytics Workspace. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceSku.property.capacityReservationLevel">capacityReservationLevel</a></code> | <code>number</code> | Capacity reservation level in GB per day Only applicable when SKU name is "CapacityReservation" Valid values: 100, 200, 300, 400, 500, 1000, 2000, 5000. |
+
+---
+
+##### `name`<sup>Required</sup> <a name="name" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceSku.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* string
+- *Default:* "PerGB2018"
+
+SKU name for the Log Analytics Workspace.
+
+Available options:
+- "Free" - Free tier (limited to 500MB/day, 7 day retention)
+- "Standard" - Standard tier (legacy)
+- "Premium" - Premium tier (legacy)
+- "PerNode" - Per node pricing (legacy, for OMS customers)
+- "PerGB2018" - Pay-as-you-go pricing based on data ingestion
+- "Standalone" - Standalone tier (legacy)
+- "CapacityReservation" - Commitment tier with reserved capacity
+
+---
+
+##### `capacityReservationLevel`<sup>Optional</sup> <a name="capacityReservationLevel" id="@microsoft/terraform-cdk-constructs.azure_loganalyticsworkspace.LogAnalyticsWorkspaceSku.property.capacityReservationLevel"></a>
+
+```typescript
+public readonly capacityReservationLevel: number;
+```
+
+- *Type:* number
+
+Capacity reservation level in GB per day Only applicable when SKU name is "CapacityReservation" Valid values: 100, 200, 300, 400, 500, 1000, 2000, 5000.
+
+---
+
 ### LogicAppReceiver <a name="LogicAppReceiver" id="@microsoft/terraform-cdk-constructs.LogicAppReceiver"></a>
 
 Logic App receiver configuration.
@@ -116528,6 +121092,630 @@ public readonly id: string;
 
 ---
 
+### NetworkWatcherBody <a name="NetworkWatcherBody" id="@microsoft/terraform-cdk-constructs.NetworkWatcherBody"></a>
+
+The resource body interface for Azure Network Watcher API calls.
+
+Network Watcher is a simple resource with minimal properties.
+The properties block is typically empty.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.NetworkWatcherBody.Initializer"></a>
+
+```typescript
+import { NetworkWatcherBody } from '@microsoft/terraform-cdk-constructs'
+
+const networkWatcherBody: NetworkWatcherBody = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcherBody.property.properties">properties</a></code> | <code>{[ key: string ]: any}</code> | *No description.* |
+
+---
+
+##### `properties`<sup>Required</sup> <a name="properties" id="@microsoft/terraform-cdk-constructs.NetworkWatcherBody.property.properties"></a>
+
+```typescript
+public readonly properties: {[ key: string ]: any};
+```
+
+- *Type:* {[ key: string ]: any}
+
+---
+
+### NetworkWatcherBody <a name="NetworkWatcherBody" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherBody"></a>
+
+The resource body interface for Azure Network Watcher API calls.
+
+Network Watcher is a simple resource with minimal properties.
+The properties block is typically empty.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherBody.Initializer"></a>
+
+```typescript
+import { azure_networkwatcher } from '@microsoft/terraform-cdk-constructs'
+
+const networkWatcherBody: azure_networkwatcher.NetworkWatcherBody = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherBody.property.properties">properties</a></code> | <code>{[ key: string ]: any}</code> | *No description.* |
+
+---
+
+##### `properties`<sup>Required</sup> <a name="properties" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherBody.property.properties"></a>
+
+```typescript
+public readonly properties: {[ key: string ]: any};
+```
+
+- *Type:* {[ key: string ]: any}
+
+---
+
+### NetworkWatcherProps <a name="NetworkWatcherProps" id="@microsoft/terraform-cdk-constructs.NetworkWatcherProps"></a>
+
+Properties for the unified Azure Network Watcher.
+
+Extends AzapiResourceProps with Network Watcher specific properties.
+
+IMPORTANT: Azure only allows one Network Watcher per subscription per region.
+Attempting to create multiple Network Watchers in the same region will fail.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.NetworkWatcherProps.Initializer"></a>
+
+```typescript
+import { NetworkWatcherProps } from '@microsoft/terraform-cdk-constructs'
+
+const networkWatcherProps: NetworkWatcherProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.connection">connection</a></code> | <code>cdktf.SSHProvisionerConnection \| cdktf.WinrmProvisionerConnection</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.count">count</a></code> | <code>number \| cdktf.TerraformCount</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.dependsOn">dependsOn</a></code> | <code>cdktf.ITerraformDependable[]</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.forEach">forEach</a></code> | <code>cdktf.ITerraformIterator</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.lifecycle">lifecycle</a></code> | <code>cdktf.TerraformResourceLifecycle</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.provider">provider</a></code> | <code>cdktf.TerraformProvider</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.provisioners">provisioners</a></code> | <code>cdktf.FileProvisioner \| cdktf.LocalExecProvisioner \| cdktf.RemoteExecProvisioner[]</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.apiVersion">apiVersion</a></code> | <code>string</code> | Explicit API version to use for this resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.enableMigrationAnalysis">enableMigrationAnalysis</a></code> | <code>boolean</code> | Whether to enable migration analysis warnings. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.enableTransformation">enableTransformation</a></code> | <code>boolean</code> | Whether to apply property transformations automatically. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.enableValidation">enableValidation</a></code> | <code>boolean</code> | Whether to validate properties against the schema. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.location">location</a></code> | <code>string</code> | The location where the resource should be created. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.monitoring">monitoring</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.MonitoringConfig</code> | Monitoring configuration for this resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.name">name</a></code> | <code>string</code> | The name of the resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.tags">tags</a></code> | <code>{[ key: string ]: string}</code> | Tags to apply to the resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.resourceGroupId">resourceGroupId</a></code> | <code>string</code> | Resource Group ID where the Network Watcher will be created. |
+
+---
+
+##### `connection`<sup>Optional</sup> <a name="connection" id="@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.connection"></a>
+
+```typescript
+public readonly connection: SSHProvisionerConnection | WinrmProvisionerConnection;
+```
+
+- *Type:* cdktf.SSHProvisionerConnection | cdktf.WinrmProvisionerConnection
+
+---
+
+##### `count`<sup>Optional</sup> <a name="count" id="@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.count"></a>
+
+```typescript
+public readonly count: number | TerraformCount;
+```
+
+- *Type:* number | cdktf.TerraformCount
+
+---
+
+##### `dependsOn`<sup>Optional</sup> <a name="dependsOn" id="@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.dependsOn"></a>
+
+```typescript
+public readonly dependsOn: ITerraformDependable[];
+```
+
+- *Type:* cdktf.ITerraformDependable[]
+
+---
+
+##### `forEach`<sup>Optional</sup> <a name="forEach" id="@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.forEach"></a>
+
+```typescript
+public readonly forEach: ITerraformIterator;
+```
+
+- *Type:* cdktf.ITerraformIterator
+
+---
+
+##### `lifecycle`<sup>Optional</sup> <a name="lifecycle" id="@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.lifecycle"></a>
+
+```typescript
+public readonly lifecycle: TerraformResourceLifecycle;
+```
+
+- *Type:* cdktf.TerraformResourceLifecycle
+
+---
+
+##### `provider`<sup>Optional</sup> <a name="provider" id="@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.provider"></a>
+
+```typescript
+public readonly provider: TerraformProvider;
+```
+
+- *Type:* cdktf.TerraformProvider
+
+---
+
+##### `provisioners`<sup>Optional</sup> <a name="provisioners" id="@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.provisioners"></a>
+
+```typescript
+public readonly provisioners: (FileProvisioner | LocalExecProvisioner | RemoteExecProvisioner)[];
+```
+
+- *Type:* cdktf.FileProvisioner | cdktf.LocalExecProvisioner | cdktf.RemoteExecProvisioner[]
+
+---
+
+##### `apiVersion`<sup>Optional</sup> <a name="apiVersion" id="@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.apiVersion"></a>
+
+```typescript
+public readonly apiVersion: string;
+```
+
+- *Type:* string
+- *Default:* Latest active version from ApiVersionManager
+
+Explicit API version to use for this resource.
+
+If not specified, the latest active version will be automatically resolved.
+Use this for version pinning when stability is required over latest features.
+
+---
+
+*Example*
+
+```typescript
+"2024-11-01"
+```
+
+
+##### `enableMigrationAnalysis`<sup>Optional</sup> <a name="enableMigrationAnalysis" id="@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.enableMigrationAnalysis"></a>
+
+```typescript
+public readonly enableMigrationAnalysis: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Whether to enable migration analysis warnings.
+
+When true, the framework will analyze the current version for deprecation
+status and provide migration recommendations in the deployment output.
+
+---
+
+##### `enableTransformation`<sup>Optional</sup> <a name="enableTransformation" id="@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.enableTransformation"></a>
+
+```typescript
+public readonly enableTransformation: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Whether to apply property transformations automatically.
+
+When true, properties will be automatically transformed according to the
+target schema's transformation rules. This enables backward compatibility.
+
+---
+
+##### `enableValidation`<sup>Optional</sup> <a name="enableValidation" id="@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.enableValidation"></a>
+
+```typescript
+public readonly enableValidation: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Whether to validate properties against the schema.
+
+When true, all properties will be validated against the API schema before
+resource creation. Validation errors will cause deployment failures.
+
+---
+
+##### `location`<sup>Optional</sup> <a name="location" id="@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.location"></a>
+
+```typescript
+public readonly location: string;
+```
+
+- *Type:* string
+- *Default:* Varies by resource type - see specific resource documentation
+
+The location where the resource should be created.
+
+---
+
+*Example*
+
+```typescript
+// Child resource (Subnet) - do not set location
+// location: undefined (inherited from parent Virtual Network)
+```
+
+
+##### `monitoring`<sup>Optional</sup> <a name="monitoring" id="@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.monitoring"></a>
+
+```typescript
+public readonly monitoring: MonitoringConfig;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.MonitoringConfig
+
+Monitoring configuration for this resource.
+
+Enables integrated monitoring with diagnostic settings, metric alerts,
+and activity log alerts. All monitoring is optional and disabled by default.
+
+---
+
+*Example*
+
+```typescript
+monitoring: {
+  enabled: true,
+  diagnosticSettings: {
+    workspaceId: logAnalytics.id,
+    metrics: ['AllMetrics'],
+    logs: ['AuditLogs']
+  },
+  metricAlerts: [{
+    name: 'high-cpu-alert',
+    severity: 2,
+    scopes: [], // Automatically set to this resource
+    criteria: { ... },
+    actions: [{ actionGroupId: actionGroup.id }]
+  }]
+}
+```
+
+
+##### `name`<sup>Optional</sup> <a name="name" id="@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* string
+
+The name of the resource.
+
+---
+
+##### `tags`<sup>Optional</sup> <a name="tags" id="@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.tags"></a>
+
+```typescript
+public readonly tags: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
+
+Tags to apply to the resource.
+
+---
+
+##### `resourceGroupId`<sup>Required</sup> <a name="resourceGroupId" id="@microsoft/terraform-cdk-constructs.NetworkWatcherProps.property.resourceGroupId"></a>
+
+```typescript
+public readonly resourceGroupId: string;
+```
+
+- *Type:* string
+
+Resource Group ID where the Network Watcher will be created.
+
+The Network Watcher will be created as a child of this resource group.
+It's recommended to use a dedicated resource group for Network Watchers,
+as Azure automatically creates one named "NetworkWatcherRG" when certain
+network features are used.
+
+---
+
+### NetworkWatcherProps <a name="NetworkWatcherProps" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps"></a>
+
+Properties for the unified Azure Network Watcher.
+
+Extends AzapiResourceProps with Network Watcher specific properties.
+
+IMPORTANT: Azure only allows one Network Watcher per subscription per region.
+Attempting to create multiple Network Watchers in the same region will fail.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.Initializer"></a>
+
+```typescript
+import { azure_networkwatcher } from '@microsoft/terraform-cdk-constructs'
+
+const networkWatcherProps: azure_networkwatcher.NetworkWatcherProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.connection">connection</a></code> | <code>cdktf.SSHProvisionerConnection \| cdktf.WinrmProvisionerConnection</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.count">count</a></code> | <code>number \| cdktf.TerraformCount</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.dependsOn">dependsOn</a></code> | <code>cdktf.ITerraformDependable[]</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.forEach">forEach</a></code> | <code>cdktf.ITerraformIterator</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.lifecycle">lifecycle</a></code> | <code>cdktf.TerraformResourceLifecycle</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.provider">provider</a></code> | <code>cdktf.TerraformProvider</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.provisioners">provisioners</a></code> | <code>cdktf.FileProvisioner \| cdktf.LocalExecProvisioner \| cdktf.RemoteExecProvisioner[]</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.apiVersion">apiVersion</a></code> | <code>string</code> | Explicit API version to use for this resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.enableMigrationAnalysis">enableMigrationAnalysis</a></code> | <code>boolean</code> | Whether to enable migration analysis warnings. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.enableTransformation">enableTransformation</a></code> | <code>boolean</code> | Whether to apply property transformations automatically. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.enableValidation">enableValidation</a></code> | <code>boolean</code> | Whether to validate properties against the schema. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.location">location</a></code> | <code>string</code> | The location where the resource should be created. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.monitoring">monitoring</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.MonitoringConfig</code> | Monitoring configuration for this resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.name">name</a></code> | <code>string</code> | The name of the resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.tags">tags</a></code> | <code>{[ key: string ]: string}</code> | Tags to apply to the resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.resourceGroupId">resourceGroupId</a></code> | <code>string</code> | Resource Group ID where the Network Watcher will be created. |
+
+---
+
+##### `connection`<sup>Optional</sup> <a name="connection" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.connection"></a>
+
+```typescript
+public readonly connection: SSHProvisionerConnection | WinrmProvisionerConnection;
+```
+
+- *Type:* cdktf.SSHProvisionerConnection | cdktf.WinrmProvisionerConnection
+
+---
+
+##### `count`<sup>Optional</sup> <a name="count" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.count"></a>
+
+```typescript
+public readonly count: number | TerraformCount;
+```
+
+- *Type:* number | cdktf.TerraformCount
+
+---
+
+##### `dependsOn`<sup>Optional</sup> <a name="dependsOn" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.dependsOn"></a>
+
+```typescript
+public readonly dependsOn: ITerraformDependable[];
+```
+
+- *Type:* cdktf.ITerraformDependable[]
+
+---
+
+##### `forEach`<sup>Optional</sup> <a name="forEach" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.forEach"></a>
+
+```typescript
+public readonly forEach: ITerraformIterator;
+```
+
+- *Type:* cdktf.ITerraformIterator
+
+---
+
+##### `lifecycle`<sup>Optional</sup> <a name="lifecycle" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.lifecycle"></a>
+
+```typescript
+public readonly lifecycle: TerraformResourceLifecycle;
+```
+
+- *Type:* cdktf.TerraformResourceLifecycle
+
+---
+
+##### `provider`<sup>Optional</sup> <a name="provider" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.provider"></a>
+
+```typescript
+public readonly provider: TerraformProvider;
+```
+
+- *Type:* cdktf.TerraformProvider
+
+---
+
+##### `provisioners`<sup>Optional</sup> <a name="provisioners" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.provisioners"></a>
+
+```typescript
+public readonly provisioners: (FileProvisioner | LocalExecProvisioner | RemoteExecProvisioner)[];
+```
+
+- *Type:* cdktf.FileProvisioner | cdktf.LocalExecProvisioner | cdktf.RemoteExecProvisioner[]
+
+---
+
+##### `apiVersion`<sup>Optional</sup> <a name="apiVersion" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.apiVersion"></a>
+
+```typescript
+public readonly apiVersion: string;
+```
+
+- *Type:* string
+- *Default:* Latest active version from ApiVersionManager
+
+Explicit API version to use for this resource.
+
+If not specified, the latest active version will be automatically resolved.
+Use this for version pinning when stability is required over latest features.
+
+---
+
+*Example*
+
+```typescript
+"2024-11-01"
+```
+
+
+##### `enableMigrationAnalysis`<sup>Optional</sup> <a name="enableMigrationAnalysis" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.enableMigrationAnalysis"></a>
+
+```typescript
+public readonly enableMigrationAnalysis: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Whether to enable migration analysis warnings.
+
+When true, the framework will analyze the current version for deprecation
+status and provide migration recommendations in the deployment output.
+
+---
+
+##### `enableTransformation`<sup>Optional</sup> <a name="enableTransformation" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.enableTransformation"></a>
+
+```typescript
+public readonly enableTransformation: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Whether to apply property transformations automatically.
+
+When true, properties will be automatically transformed according to the
+target schema's transformation rules. This enables backward compatibility.
+
+---
+
+##### `enableValidation`<sup>Optional</sup> <a name="enableValidation" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.enableValidation"></a>
+
+```typescript
+public readonly enableValidation: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Whether to validate properties against the schema.
+
+When true, all properties will be validated against the API schema before
+resource creation. Validation errors will cause deployment failures.
+
+---
+
+##### `location`<sup>Optional</sup> <a name="location" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.location"></a>
+
+```typescript
+public readonly location: string;
+```
+
+- *Type:* string
+- *Default:* Varies by resource type - see specific resource documentation
+
+The location where the resource should be created.
+
+---
+
+*Example*
+
+```typescript
+// Child resource (Subnet) - do not set location
+// location: undefined (inherited from parent Virtual Network)
+```
+
+
+##### `monitoring`<sup>Optional</sup> <a name="monitoring" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.monitoring"></a>
+
+```typescript
+public readonly monitoring: MonitoringConfig;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.MonitoringConfig
+
+Monitoring configuration for this resource.
+
+Enables integrated monitoring with diagnostic settings, metric alerts,
+and activity log alerts. All monitoring is optional and disabled by default.
+
+---
+
+*Example*
+
+```typescript
+monitoring: {
+  enabled: true,
+  diagnosticSettings: {
+    workspaceId: logAnalytics.id,
+    metrics: ['AllMetrics'],
+    logs: ['AuditLogs']
+  },
+  metricAlerts: [{
+    name: 'high-cpu-alert',
+    severity: 2,
+    scopes: [], // Automatically set to this resource
+    criteria: { ... },
+    actions: [{ actionGroupId: actionGroup.id }]
+  }]
+}
+```
+
+
+##### `name`<sup>Optional</sup> <a name="name" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* string
+
+The name of the resource.
+
+---
+
+##### `tags`<sup>Optional</sup> <a name="tags" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.tags"></a>
+
+```typescript
+public readonly tags: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
+
+Tags to apply to the resource.
+
+---
+
+##### `resourceGroupId`<sup>Required</sup> <a name="resourceGroupId" id="@microsoft/terraform-cdk-constructs.azure_networkwatcher.NetworkWatcherProps.property.resourceGroupId"></a>
+
+```typescript
+public readonly resourceGroupId: string;
+```
+
+- *Type:* string
+
+Resource Group ID where the Network Watcher will be created.
+
+The Network Watcher will be created as a child of this resource group.
+It's recommended to use a dedicated resource group for Network Watchers,
+as Azure automatically creates one named "NetworkWatcherRG" when certain
+network features are used.
+
+---
+
 ### OrphanedResource <a name="OrphanedResource" id="@microsoft/terraform-cdk-constructs.OrphanedResource"></a>
 
 Orphaned resource information.
@@ -118738,6 +123926,244 @@ The properties of the policy definition.
 
 ---
 
+### PolicyDefinitionGroup <a name="PolicyDefinitionGroup" id="@microsoft/terraform-cdk-constructs.PolicyDefinitionGroup"></a>
+
+A group for organizing policy definitions within a policy set.
+
+Groups provide a way to categorize and organize policies within an initiative
+for better management and compliance reporting.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.PolicyDefinitionGroup.Initializer"></a>
+
+```typescript
+import { PolicyDefinitionGroup } from '@microsoft/terraform-cdk-constructs'
+
+const policyDefinitionGroup: PolicyDefinitionGroup = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicyDefinitionGroup.property.name">name</a></code> | <code>string</code> | The name of the group (must be unique within the policy set). |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicyDefinitionGroup.property.additionalMetadataId">additionalMetadataId</a></code> | <code>string</code> | Additional metadata for the group. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicyDefinitionGroup.property.category">category</a></code> | <code>string</code> | The category this group belongs to. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicyDefinitionGroup.property.description">description</a></code> | <code>string</code> | A description of the group's purpose. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicyDefinitionGroup.property.displayName">displayName</a></code> | <code>string</code> | The display name of the group shown in Azure Portal. |
+
+---
+
+##### `name`<sup>Required</sup> <a name="name" id="@microsoft/terraform-cdk-constructs.PolicyDefinitionGroup.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* string
+
+The name of the group (must be unique within the policy set).
+
+This name is referenced by policy definitions to indicate membership.
+
+---
+
+*Example*
+
+```typescript
+"Security"
+```
+
+
+##### `additionalMetadataId`<sup>Optional</sup> <a name="additionalMetadataId" id="@microsoft/terraform-cdk-constructs.PolicyDefinitionGroup.property.additionalMetadataId"></a>
+
+```typescript
+public readonly additionalMetadataId: string;
+```
+
+- *Type:* string
+
+Additional metadata for the group.
+
+---
+
+##### `category`<sup>Optional</sup> <a name="category" id="@microsoft/terraform-cdk-constructs.PolicyDefinitionGroup.property.category"></a>
+
+```typescript
+public readonly category: string;
+```
+
+- *Type:* string
+
+The category this group belongs to.
+
+Categories help organize groups and are displayed in the Azure Portal.
+
+---
+
+*Example*
+
+```typescript
+"Security Center"
+```
+
+
+##### `description`<sup>Optional</sup> <a name="description" id="@microsoft/terraform-cdk-constructs.PolicyDefinitionGroup.property.description"></a>
+
+```typescript
+public readonly description: string;
+```
+
+- *Type:* string
+
+A description of the group's purpose.
+
+---
+
+*Example*
+
+```typescript
+"Policies related to security configuration and compliance"
+```
+
+
+##### `displayName`<sup>Optional</sup> <a name="displayName" id="@microsoft/terraform-cdk-constructs.PolicyDefinitionGroup.property.displayName"></a>
+
+```typescript
+public readonly displayName: string;
+```
+
+- *Type:* string
+
+The display name of the group shown in Azure Portal.
+
+---
+
+*Example*
+
+```typescript
+"Security Policies"
+```
+
+
+### PolicyDefinitionGroup <a name="PolicyDefinitionGroup" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionGroup"></a>
+
+A group for organizing policy definitions within a policy set.
+
+Groups provide a way to categorize and organize policies within an initiative
+for better management and compliance reporting.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionGroup.Initializer"></a>
+
+```typescript
+import { azure_policysetdefinition } from '@microsoft/terraform-cdk-constructs'
+
+const policyDefinitionGroup: azure_policysetdefinition.PolicyDefinitionGroup = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionGroup.property.name">name</a></code> | <code>string</code> | The name of the group (must be unique within the policy set). |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionGroup.property.additionalMetadataId">additionalMetadataId</a></code> | <code>string</code> | Additional metadata for the group. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionGroup.property.category">category</a></code> | <code>string</code> | The category this group belongs to. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionGroup.property.description">description</a></code> | <code>string</code> | A description of the group's purpose. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionGroup.property.displayName">displayName</a></code> | <code>string</code> | The display name of the group shown in Azure Portal. |
+
+---
+
+##### `name`<sup>Required</sup> <a name="name" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionGroup.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* string
+
+The name of the group (must be unique within the policy set).
+
+This name is referenced by policy definitions to indicate membership.
+
+---
+
+*Example*
+
+```typescript
+"Security"
+```
+
+
+##### `additionalMetadataId`<sup>Optional</sup> <a name="additionalMetadataId" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionGroup.property.additionalMetadataId"></a>
+
+```typescript
+public readonly additionalMetadataId: string;
+```
+
+- *Type:* string
+
+Additional metadata for the group.
+
+---
+
+##### `category`<sup>Optional</sup> <a name="category" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionGroup.property.category"></a>
+
+```typescript
+public readonly category: string;
+```
+
+- *Type:* string
+
+The category this group belongs to.
+
+Categories help organize groups and are displayed in the Azure Portal.
+
+---
+
+*Example*
+
+```typescript
+"Security Center"
+```
+
+
+##### `description`<sup>Optional</sup> <a name="description" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionGroup.property.description"></a>
+
+```typescript
+public readonly description: string;
+```
+
+- *Type:* string
+
+A description of the group's purpose.
+
+---
+
+*Example*
+
+```typescript
+"Policies related to security configuration and compliance"
+```
+
+
+##### `displayName`<sup>Optional</sup> <a name="displayName" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionGroup.property.displayName"></a>
+
+```typescript
+public readonly displayName: string;
+```
+
+- *Type:* string
+
+The display name of the group shown in Azure Portal.
+
+---
+
+*Example*
+
+```typescript
+"Security Policies"
+```
+
+
 ### PolicyDefinitionProperties <a name="PolicyDefinitionProperties" id="@microsoft/terraform-cdk-constructs.PolicyDefinitionProperties"></a>
 
 Properties interface for Azure Policy Definition This is required for JSII compliance to support multi-language code generation.
@@ -119877,6 +125303,1896 @@ The type of policy definition.
 "Custom", "BuiltIn", "Static", "NotSpecified"
 ```
 
+
+### PolicyDefinitionReference <a name="PolicyDefinitionReference" id="@microsoft/terraform-cdk-constructs.PolicyDefinitionReference"></a>
+
+A reference to a policy definition within a policy set.
+
+This defines which policy definitions are included in the initiative
+and how they are configured with parameters.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.PolicyDefinitionReference.Initializer"></a>
+
+```typescript
+import { PolicyDefinitionReference } from '@microsoft/terraform-cdk-constructs'
+
+const policyDefinitionReference: PolicyDefinitionReference = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicyDefinitionReference.property.policyDefinitionId">policyDefinitionId</a></code> | <code>string</code> | The ID of the policy definition to include in the set. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicyDefinitionReference.property.groupNames">groupNames</a></code> | <code>string[]</code> | Group names that this policy definition belongs to. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicyDefinitionReference.property.parameters">parameters</a></code> | <code>{[ key: string ]: @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyParameterValue}</code> | Parameter values for this policy definition. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicyDefinitionReference.property.policyDefinitionReferenceId">policyDefinitionReferenceId</a></code> | <code>string</code> | A unique identifier for this policy definition reference within the set. |
+
+---
+
+##### `policyDefinitionId`<sup>Required</sup> <a name="policyDefinitionId" id="@microsoft/terraform-cdk-constructs.PolicyDefinitionReference.property.policyDefinitionId"></a>
+
+```typescript
+public readonly policyDefinitionId: string;
+```
+
+- *Type:* string
+
+The ID of the policy definition to include in the set.
+
+This can be:
+- A built-in policy: /providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionId}
+- A custom policy at subscription level: /subscriptions/{subscriptionId}/providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionId}
+- A custom policy at management group level: /providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionId}
+
+---
+
+*Example*
+
+```typescript
+"/providers/Microsoft.Authorization/policyDefinitions/06a78e20-9358-41c9-923c-fb736d382a4d"
+```
+
+
+##### `groupNames`<sup>Optional</sup> <a name="groupNames" id="@microsoft/terraform-cdk-constructs.PolicyDefinitionReference.property.groupNames"></a>
+
+```typescript
+public readonly groupNames: string[];
+```
+
+- *Type:* string[]
+
+Group names that this policy definition belongs to.
+
+Groups help organize policies within an initiative and can be used
+for compliance reporting and management.
+
+---
+
+*Example*
+
+```typescript
+["Security", "Compliance"]
+```
+
+
+##### `parameters`<sup>Optional</sup> <a name="parameters" id="@microsoft/terraform-cdk-constructs.PolicyDefinitionReference.property.parameters"></a>
+
+```typescript
+public readonly parameters: {[ key: string ]: PolicyParameterValue};
+```
+
+- *Type:* {[ key: string ]: @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyParameterValue}
+
+Parameter values for this policy definition.
+
+These values override the default parameter values in the policy definition.
+Parameters can reference initiative-level parameters using the format:
+{ "value": "[parameters('initiativeParameterName')]" }
+
+---
+
+*Example*
+
+```typescript
+{ "tagName": { "value": "environment" }, "tagValue": { "value": "[parameters('requiredTagValue')]" } }
+```
+
+
+##### `policyDefinitionReferenceId`<sup>Optional</sup> <a name="policyDefinitionReferenceId" id="@microsoft/terraform-cdk-constructs.PolicyDefinitionReference.property.policyDefinitionReferenceId"></a>
+
+```typescript
+public readonly policyDefinitionReferenceId: string;
+```
+
+- *Type:* string
+
+A unique identifier for this policy definition reference within the set.
+
+This ID is used to reference this specific policy in the initiative
+and must be unique within the policy set definition.
+
+---
+
+*Example*
+
+```typescript
+"auditVMsWithoutTags"
+```
+
+
+### PolicyDefinitionReference <a name="PolicyDefinitionReference" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionReference"></a>
+
+A reference to a policy definition within a policy set.
+
+This defines which policy definitions are included in the initiative
+and how they are configured with parameters.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionReference.Initializer"></a>
+
+```typescript
+import { azure_policysetdefinition } from '@microsoft/terraform-cdk-constructs'
+
+const policyDefinitionReference: azure_policysetdefinition.PolicyDefinitionReference = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionReference.property.policyDefinitionId">policyDefinitionId</a></code> | <code>string</code> | The ID of the policy definition to include in the set. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionReference.property.groupNames">groupNames</a></code> | <code>string[]</code> | Group names that this policy definition belongs to. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionReference.property.parameters">parameters</a></code> | <code>{[ key: string ]: @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyParameterValue}</code> | Parameter values for this policy definition. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionReference.property.policyDefinitionReferenceId">policyDefinitionReferenceId</a></code> | <code>string</code> | A unique identifier for this policy definition reference within the set. |
+
+---
+
+##### `policyDefinitionId`<sup>Required</sup> <a name="policyDefinitionId" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionReference.property.policyDefinitionId"></a>
+
+```typescript
+public readonly policyDefinitionId: string;
+```
+
+- *Type:* string
+
+The ID of the policy definition to include in the set.
+
+This can be:
+- A built-in policy: /providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionId}
+- A custom policy at subscription level: /subscriptions/{subscriptionId}/providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionId}
+- A custom policy at management group level: /providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionId}
+
+---
+
+*Example*
+
+```typescript
+"/providers/Microsoft.Authorization/policyDefinitions/06a78e20-9358-41c9-923c-fb736d382a4d"
+```
+
+
+##### `groupNames`<sup>Optional</sup> <a name="groupNames" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionReference.property.groupNames"></a>
+
+```typescript
+public readonly groupNames: string[];
+```
+
+- *Type:* string[]
+
+Group names that this policy definition belongs to.
+
+Groups help organize policies within an initiative and can be used
+for compliance reporting and management.
+
+---
+
+*Example*
+
+```typescript
+["Security", "Compliance"]
+```
+
+
+##### `parameters`<sup>Optional</sup> <a name="parameters" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionReference.property.parameters"></a>
+
+```typescript
+public readonly parameters: {[ key: string ]: PolicyParameterValue};
+```
+
+- *Type:* {[ key: string ]: @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyParameterValue}
+
+Parameter values for this policy definition.
+
+These values override the default parameter values in the policy definition.
+Parameters can reference initiative-level parameters using the format:
+{ "value": "[parameters('initiativeParameterName')]" }
+
+---
+
+*Example*
+
+```typescript
+{ "tagName": { "value": "environment" }, "tagValue": { "value": "[parameters('requiredTagValue')]" } }
+```
+
+
+##### `policyDefinitionReferenceId`<sup>Optional</sup> <a name="policyDefinitionReferenceId" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionReference.property.policyDefinitionReferenceId"></a>
+
+```typescript
+public readonly policyDefinitionReferenceId: string;
+```
+
+- *Type:* string
+
+A unique identifier for this policy definition reference within the set.
+
+This ID is used to reference this specific policy in the initiative
+and must be unique within the policy set definition.
+
+---
+
+*Example*
+
+```typescript
+"auditVMsWithoutTags"
+```
+
+
+### PolicyParameterValue <a name="PolicyParameterValue" id="@microsoft/terraform-cdk-constructs.PolicyParameterValue"></a>
+
+A parameter value, either a direct value or a reference.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.PolicyParameterValue.Initializer"></a>
+
+```typescript
+import { PolicyParameterValue } from '@microsoft/terraform-cdk-constructs'
+
+const policyParameterValue: PolicyParameterValue = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicyParameterValue.property.value">value</a></code> | <code>any</code> | The value of the parameter. |
+
+---
+
+##### `value`<sup>Required</sup> <a name="value" id="@microsoft/terraform-cdk-constructs.PolicyParameterValue.property.value"></a>
+
+```typescript
+public readonly value: any;
+```
+
+- *Type:* any
+
+The value of the parameter.
+
+Can be a direct value or a reference to an initiative parameter
+using the format: "[parameters('parameterName')]"
+
+---
+
+### PolicyParameterValue <a name="PolicyParameterValue" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyParameterValue"></a>
+
+A parameter value, either a direct value or a reference.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyParameterValue.Initializer"></a>
+
+```typescript
+import { azure_policysetdefinition } from '@microsoft/terraform-cdk-constructs'
+
+const policyParameterValue: azure_policysetdefinition.PolicyParameterValue = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyParameterValue.property.value">value</a></code> | <code>any</code> | The value of the parameter. |
+
+---
+
+##### `value`<sup>Required</sup> <a name="value" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyParameterValue.property.value"></a>
+
+```typescript
+public readonly value: any;
+```
+
+- *Type:* any
+
+The value of the parameter.
+
+Can be a direct value or a reference to an initiative parameter
+using the format: "[parameters('parameterName')]"
+
+---
+
+### PolicySetDefinitionBody <a name="PolicySetDefinitionBody" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionBody"></a>
+
+The resource body interface for Azure Policy Set Definition API calls This matches the Azure REST API schema for policy set definitions.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionBody.Initializer"></a>
+
+```typescript
+import { PolicySetDefinitionBody } from '@microsoft/terraform-cdk-constructs'
+
+const policySetDefinitionBody: PolicySetDefinitionBody = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionBody.property.properties">properties</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProperties</code> | The properties of the policy set definition. |
+
+---
+
+##### `properties`<sup>Required</sup> <a name="properties" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionBody.property.properties"></a>
+
+```typescript
+public readonly properties: PolicySetDefinitionProperties;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProperties
+
+The properties of the policy set definition.
+
+---
+
+### PolicySetDefinitionBody <a name="PolicySetDefinitionBody" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionBody"></a>
+
+The resource body interface for Azure Policy Set Definition API calls This matches the Azure REST API schema for policy set definitions.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionBody.Initializer"></a>
+
+```typescript
+import { azure_policysetdefinition } from '@microsoft/terraform-cdk-constructs'
+
+const policySetDefinitionBody: azure_policysetdefinition.PolicySetDefinitionBody = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionBody.property.properties">properties</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProperties</code> | The properties of the policy set definition. |
+
+---
+
+##### `properties`<sup>Required</sup> <a name="properties" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionBody.property.properties"></a>
+
+```typescript
+public readonly properties: PolicySetDefinitionProperties;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProperties
+
+The properties of the policy set definition.
+
+---
+
+### PolicySetDefinitionProperties <a name="PolicySetDefinitionProperties" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProperties"></a>
+
+Properties interface for Azure Policy Set Definition This is required for JSII compliance to support multi-language code generation.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProperties.Initializer"></a>
+
+```typescript
+import { PolicySetDefinitionProperties } from '@microsoft/terraform-cdk-constructs'
+
+const policySetDefinitionProperties: PolicySetDefinitionProperties = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProperties.property.displayName">displayName</a></code> | <code>string</code> | The display name of the policy set definition. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProperties.property.policyDefinitions">policyDefinitions</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionReference[]</code> | Array of policy definition references. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProperties.property.description">description</a></code> | <code>string</code> | Description of the policy set definition. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProperties.property.metadata">metadata</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetMetadata</code> | Metadata for the policy set definition. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProperties.property.parameters">parameters</a></code> | <code>{[ key: string ]: @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterDefinition}</code> | Parameter definitions for the policy set. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProperties.property.policyDefinitionGroups">policyDefinitionGroups</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionGroup[]</code> | Groups for organizing policy definitions. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProperties.property.policyType">policyType</a></code> | <code>string</code> | The type of policy set definition. |
+
+---
+
+##### `displayName`<sup>Required</sup> <a name="displayName" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProperties.property.displayName"></a>
+
+```typescript
+public readonly displayName: string;
+```
+
+- *Type:* string
+
+The display name of the policy set definition.
+
+---
+
+##### `policyDefinitions`<sup>Required</sup> <a name="policyDefinitions" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProperties.property.policyDefinitions"></a>
+
+```typescript
+public readonly policyDefinitions: PolicyDefinitionReference[];
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionReference[]
+
+Array of policy definition references.
+
+---
+
+##### `description`<sup>Optional</sup> <a name="description" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProperties.property.description"></a>
+
+```typescript
+public readonly description: string;
+```
+
+- *Type:* string
+
+Description of the policy set definition.
+
+---
+
+##### `metadata`<sup>Optional</sup> <a name="metadata" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProperties.property.metadata"></a>
+
+```typescript
+public readonly metadata: PolicySetMetadata;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetMetadata
+
+Metadata for the policy set definition.
+
+---
+
+##### `parameters`<sup>Optional</sup> <a name="parameters" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProperties.property.parameters"></a>
+
+```typescript
+public readonly parameters: {[ key: string ]: PolicySetParameterDefinition};
+```
+
+- *Type:* {[ key: string ]: @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterDefinition}
+
+Parameter definitions for the policy set.
+
+---
+
+##### `policyDefinitionGroups`<sup>Optional</sup> <a name="policyDefinitionGroups" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProperties.property.policyDefinitionGroups"></a>
+
+```typescript
+public readonly policyDefinitionGroups: PolicyDefinitionGroup[];
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionGroup[]
+
+Groups for organizing policy definitions.
+
+---
+
+##### `policyType`<sup>Optional</sup> <a name="policyType" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProperties.property.policyType"></a>
+
+```typescript
+public readonly policyType: string;
+```
+
+- *Type:* string
+
+The type of policy set definition.
+
+---
+
+### PolicySetDefinitionProperties <a name="PolicySetDefinitionProperties" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProperties"></a>
+
+Properties interface for Azure Policy Set Definition This is required for JSII compliance to support multi-language code generation.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProperties.Initializer"></a>
+
+```typescript
+import { azure_policysetdefinition } from '@microsoft/terraform-cdk-constructs'
+
+const policySetDefinitionProperties: azure_policysetdefinition.PolicySetDefinitionProperties = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProperties.property.displayName">displayName</a></code> | <code>string</code> | The display name of the policy set definition. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProperties.property.policyDefinitions">policyDefinitions</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionReference[]</code> | Array of policy definition references. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProperties.property.description">description</a></code> | <code>string</code> | Description of the policy set definition. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProperties.property.metadata">metadata</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetMetadata</code> | Metadata for the policy set definition. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProperties.property.parameters">parameters</a></code> | <code>{[ key: string ]: @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterDefinition}</code> | Parameter definitions for the policy set. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProperties.property.policyDefinitionGroups">policyDefinitionGroups</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionGroup[]</code> | Groups for organizing policy definitions. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProperties.property.policyType">policyType</a></code> | <code>string</code> | The type of policy set definition. |
+
+---
+
+##### `displayName`<sup>Required</sup> <a name="displayName" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProperties.property.displayName"></a>
+
+```typescript
+public readonly displayName: string;
+```
+
+- *Type:* string
+
+The display name of the policy set definition.
+
+---
+
+##### `policyDefinitions`<sup>Required</sup> <a name="policyDefinitions" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProperties.property.policyDefinitions"></a>
+
+```typescript
+public readonly policyDefinitions: PolicyDefinitionReference[];
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionReference[]
+
+Array of policy definition references.
+
+---
+
+##### `description`<sup>Optional</sup> <a name="description" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProperties.property.description"></a>
+
+```typescript
+public readonly description: string;
+```
+
+- *Type:* string
+
+Description of the policy set definition.
+
+---
+
+##### `metadata`<sup>Optional</sup> <a name="metadata" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProperties.property.metadata"></a>
+
+```typescript
+public readonly metadata: PolicySetMetadata;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetMetadata
+
+Metadata for the policy set definition.
+
+---
+
+##### `parameters`<sup>Optional</sup> <a name="parameters" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProperties.property.parameters"></a>
+
+```typescript
+public readonly parameters: {[ key: string ]: PolicySetParameterDefinition};
+```
+
+- *Type:* {[ key: string ]: @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterDefinition}
+
+Parameter definitions for the policy set.
+
+---
+
+##### `policyDefinitionGroups`<sup>Optional</sup> <a name="policyDefinitionGroups" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProperties.property.policyDefinitionGroups"></a>
+
+```typescript
+public readonly policyDefinitionGroups: PolicyDefinitionGroup[];
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionGroup[]
+
+Groups for organizing policy definitions.
+
+---
+
+##### `policyType`<sup>Optional</sup> <a name="policyType" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProperties.property.policyType"></a>
+
+```typescript
+public readonly policyType: string;
+```
+
+- *Type:* string
+
+The type of policy set definition.
+
+---
+
+### PolicySetDefinitionProps <a name="PolicySetDefinitionProps" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps"></a>
+
+Properties for the unified Azure Policy Set Definition.
+
+Extends AzapiResourceProps with Policy Set Definition specific properties
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.Initializer"></a>
+
+```typescript
+import { PolicySetDefinitionProps } from '@microsoft/terraform-cdk-constructs'
+
+const policySetDefinitionProps: PolicySetDefinitionProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.connection">connection</a></code> | <code>cdktf.SSHProvisionerConnection \| cdktf.WinrmProvisionerConnection</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.count">count</a></code> | <code>number \| cdktf.TerraformCount</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.dependsOn">dependsOn</a></code> | <code>cdktf.ITerraformDependable[]</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.forEach">forEach</a></code> | <code>cdktf.ITerraformIterator</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.lifecycle">lifecycle</a></code> | <code>cdktf.TerraformResourceLifecycle</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.provider">provider</a></code> | <code>cdktf.TerraformProvider</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.provisioners">provisioners</a></code> | <code>cdktf.FileProvisioner \| cdktf.LocalExecProvisioner \| cdktf.RemoteExecProvisioner[]</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.apiVersion">apiVersion</a></code> | <code>string</code> | Explicit API version to use for this resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.enableMigrationAnalysis">enableMigrationAnalysis</a></code> | <code>boolean</code> | Whether to enable migration analysis warnings. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.enableTransformation">enableTransformation</a></code> | <code>boolean</code> | Whether to apply property transformations automatically. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.enableValidation">enableValidation</a></code> | <code>boolean</code> | Whether to validate properties against the schema. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.location">location</a></code> | <code>string</code> | The location where the resource should be created. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.monitoring">monitoring</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.MonitoringConfig</code> | Monitoring configuration for this resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.name">name</a></code> | <code>string</code> | The name of the resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.tags">tags</a></code> | <code>{[ key: string ]: string}</code> | Tags to apply to the resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.displayName">displayName</a></code> | <code>string</code> | The display name of the policy set definition. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.policyDefinitions">policyDefinitions</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionReference[]</code> | Array of policy definition references. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.scope">scope</a></code> | <code>string</code> | The scope at which to create the policy set definition. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.description">description</a></code> | <code>string</code> | Description of the policy set definition. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.metadata">metadata</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetMetadata</code> | Metadata for the policy set definition. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.parameters">parameters</a></code> | <code>{[ key: string ]: @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterDefinition}</code> | Parameter definitions for the policy set. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.policyDefinitionGroups">policyDefinitionGroups</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionGroup[]</code> | Groups for organizing policy definitions in the set. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.policyType">policyType</a></code> | <code>string</code> | The type of policy set definition. |
+
+---
+
+##### `connection`<sup>Optional</sup> <a name="connection" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.connection"></a>
+
+```typescript
+public readonly connection: SSHProvisionerConnection | WinrmProvisionerConnection;
+```
+
+- *Type:* cdktf.SSHProvisionerConnection | cdktf.WinrmProvisionerConnection
+
+---
+
+##### `count`<sup>Optional</sup> <a name="count" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.count"></a>
+
+```typescript
+public readonly count: number | TerraformCount;
+```
+
+- *Type:* number | cdktf.TerraformCount
+
+---
+
+##### `dependsOn`<sup>Optional</sup> <a name="dependsOn" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.dependsOn"></a>
+
+```typescript
+public readonly dependsOn: ITerraformDependable[];
+```
+
+- *Type:* cdktf.ITerraformDependable[]
+
+---
+
+##### `forEach`<sup>Optional</sup> <a name="forEach" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.forEach"></a>
+
+```typescript
+public readonly forEach: ITerraformIterator;
+```
+
+- *Type:* cdktf.ITerraformIterator
+
+---
+
+##### `lifecycle`<sup>Optional</sup> <a name="lifecycle" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.lifecycle"></a>
+
+```typescript
+public readonly lifecycle: TerraformResourceLifecycle;
+```
+
+- *Type:* cdktf.TerraformResourceLifecycle
+
+---
+
+##### `provider`<sup>Optional</sup> <a name="provider" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.provider"></a>
+
+```typescript
+public readonly provider: TerraformProvider;
+```
+
+- *Type:* cdktf.TerraformProvider
+
+---
+
+##### `provisioners`<sup>Optional</sup> <a name="provisioners" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.provisioners"></a>
+
+```typescript
+public readonly provisioners: (FileProvisioner | LocalExecProvisioner | RemoteExecProvisioner)[];
+```
+
+- *Type:* cdktf.FileProvisioner | cdktf.LocalExecProvisioner | cdktf.RemoteExecProvisioner[]
+
+---
+
+##### `apiVersion`<sup>Optional</sup> <a name="apiVersion" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.apiVersion"></a>
+
+```typescript
+public readonly apiVersion: string;
+```
+
+- *Type:* string
+- *Default:* Latest active version from ApiVersionManager
+
+Explicit API version to use for this resource.
+
+If not specified, the latest active version will be automatically resolved.
+Use this for version pinning when stability is required over latest features.
+
+---
+
+*Example*
+
+```typescript
+"2024-11-01"
+```
+
+
+##### `enableMigrationAnalysis`<sup>Optional</sup> <a name="enableMigrationAnalysis" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.enableMigrationAnalysis"></a>
+
+```typescript
+public readonly enableMigrationAnalysis: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Whether to enable migration analysis warnings.
+
+When true, the framework will analyze the current version for deprecation
+status and provide migration recommendations in the deployment output.
+
+---
+
+##### `enableTransformation`<sup>Optional</sup> <a name="enableTransformation" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.enableTransformation"></a>
+
+```typescript
+public readonly enableTransformation: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Whether to apply property transformations automatically.
+
+When true, properties will be automatically transformed according to the
+target schema's transformation rules. This enables backward compatibility.
+
+---
+
+##### `enableValidation`<sup>Optional</sup> <a name="enableValidation" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.enableValidation"></a>
+
+```typescript
+public readonly enableValidation: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Whether to validate properties against the schema.
+
+When true, all properties will be validated against the API schema before
+resource creation. Validation errors will cause deployment failures.
+
+---
+
+##### `location`<sup>Optional</sup> <a name="location" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.location"></a>
+
+```typescript
+public readonly location: string;
+```
+
+- *Type:* string
+- *Default:* Varies by resource type - see specific resource documentation
+
+The location where the resource should be created.
+
+---
+
+*Example*
+
+```typescript
+// Child resource (Subnet) - do not set location
+// location: undefined (inherited from parent Virtual Network)
+```
+
+
+##### `monitoring`<sup>Optional</sup> <a name="monitoring" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.monitoring"></a>
+
+```typescript
+public readonly monitoring: MonitoringConfig;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.MonitoringConfig
+
+Monitoring configuration for this resource.
+
+Enables integrated monitoring with diagnostic settings, metric alerts,
+and activity log alerts. All monitoring is optional and disabled by default.
+
+---
+
+*Example*
+
+```typescript
+monitoring: {
+  enabled: true,
+  diagnosticSettings: {
+    workspaceId: logAnalytics.id,
+    metrics: ['AllMetrics'],
+    logs: ['AuditLogs']
+  },
+  metricAlerts: [{
+    name: 'high-cpu-alert',
+    severity: 2,
+    scopes: [], // Automatically set to this resource
+    criteria: { ... },
+    actions: [{ actionGroupId: actionGroup.id }]
+  }]
+}
+```
+
+
+##### `name`<sup>Optional</sup> <a name="name" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* string
+
+The name of the resource.
+
+---
+
+##### `tags`<sup>Optional</sup> <a name="tags" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.tags"></a>
+
+```typescript
+public readonly tags: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
+
+Tags to apply to the resource.
+
+---
+
+##### `displayName`<sup>Required</sup> <a name="displayName" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.displayName"></a>
+
+```typescript
+public readonly displayName: string;
+```
+
+- *Type:* string
+
+The display name of the policy set definition.
+
+This is the name shown in the Azure Portal.
+Required property.
+
+---
+
+*Example*
+
+```typescript
+"Security Baseline Initiative"
+```
+
+
+##### `policyDefinitions`<sup>Required</sup> <a name="policyDefinitions" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.policyDefinitions"></a>
+
+```typescript
+public readonly policyDefinitions: PolicyDefinitionReference[];
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionReference[]
+
+Array of policy definition references.
+
+Each reference specifies a policy definition to include in the set
+along with its parameter values and group memberships.
+Required property.
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.scope"></a>
+
+```typescript
+public readonly scope: string;
+```
+
+- *Type:* string
+
+The scope at which to create the policy set definition.
+
+This can be:
+- A subscription: /subscriptions/{subscriptionId}
+- A management group: /providers/Microsoft.Management/managementGroups/{managementGroupId}
+
+---
+
+*Example*
+
+```typescript
+"/providers/Microsoft.Management/managementGroups/my-management-group"
+```
+
+
+##### `description`<sup>Optional</sup> <a name="description" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.description"></a>
+
+```typescript
+public readonly description: string;
+```
+
+- *Type:* string
+
+Description of the policy set definition.
+
+---
+
+*Example*
+
+```typescript
+"This initiative applies a set of security policies to ensure baseline compliance."
+```
+
+
+##### `metadata`<sup>Optional</sup> <a name="metadata" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.metadata"></a>
+
+```typescript
+public readonly metadata: PolicySetMetadata;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetMetadata
+
+Metadata for the policy set definition.
+
+Includes category, version, preview, and deprecated flags.
+
+---
+
+##### `parameters`<sup>Optional</sup> <a name="parameters" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.parameters"></a>
+
+```typescript
+public readonly parameters: {[ key: string ]: PolicySetParameterDefinition};
+```
+
+- *Type:* {[ key: string ]: @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterDefinition}
+
+Parameter definitions for the policy set.
+
+These parameters can be referenced by policy definitions in the set
+using the format: "[parameters('parameterName')]"
+
+---
+
+##### `policyDefinitionGroups`<sup>Optional</sup> <a name="policyDefinitionGroups" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.policyDefinitionGroups"></a>
+
+```typescript
+public readonly policyDefinitionGroups: PolicyDefinitionGroup[];
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionGroup[]
+
+Groups for organizing policy definitions in the set.
+
+Groups help categorize policies for management and compliance reporting.
+
+---
+
+##### `policyType`<sup>Optional</sup> <a name="policyType" id="@microsoft/terraform-cdk-constructs.PolicySetDefinitionProps.property.policyType"></a>
+
+```typescript
+public readonly policyType: string;
+```
+
+- *Type:* string
+- *Default:* "Custom"
+
+The type of policy set definition.
+
+---
+
+### PolicySetDefinitionProps <a name="PolicySetDefinitionProps" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps"></a>
+
+Properties for the unified Azure Policy Set Definition.
+
+Extends AzapiResourceProps with Policy Set Definition specific properties
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.Initializer"></a>
+
+```typescript
+import { azure_policysetdefinition } from '@microsoft/terraform-cdk-constructs'
+
+const policySetDefinitionProps: azure_policysetdefinition.PolicySetDefinitionProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.connection">connection</a></code> | <code>cdktf.SSHProvisionerConnection \| cdktf.WinrmProvisionerConnection</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.count">count</a></code> | <code>number \| cdktf.TerraformCount</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.dependsOn">dependsOn</a></code> | <code>cdktf.ITerraformDependable[]</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.forEach">forEach</a></code> | <code>cdktf.ITerraformIterator</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.lifecycle">lifecycle</a></code> | <code>cdktf.TerraformResourceLifecycle</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.provider">provider</a></code> | <code>cdktf.TerraformProvider</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.provisioners">provisioners</a></code> | <code>cdktf.FileProvisioner \| cdktf.LocalExecProvisioner \| cdktf.RemoteExecProvisioner[]</code> | *No description.* |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.apiVersion">apiVersion</a></code> | <code>string</code> | Explicit API version to use for this resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.enableMigrationAnalysis">enableMigrationAnalysis</a></code> | <code>boolean</code> | Whether to enable migration analysis warnings. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.enableTransformation">enableTransformation</a></code> | <code>boolean</code> | Whether to apply property transformations automatically. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.enableValidation">enableValidation</a></code> | <code>boolean</code> | Whether to validate properties against the schema. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.location">location</a></code> | <code>string</code> | The location where the resource should be created. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.monitoring">monitoring</a></code> | <code>@microsoft/terraform-cdk-constructs.core_azure.MonitoringConfig</code> | Monitoring configuration for this resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.name">name</a></code> | <code>string</code> | The name of the resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.tags">tags</a></code> | <code>{[ key: string ]: string}</code> | Tags to apply to the resource. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.displayName">displayName</a></code> | <code>string</code> | The display name of the policy set definition. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.policyDefinitions">policyDefinitions</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionReference[]</code> | Array of policy definition references. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.scope">scope</a></code> | <code>string</code> | The scope at which to create the policy set definition. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.description">description</a></code> | <code>string</code> | Description of the policy set definition. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.metadata">metadata</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetMetadata</code> | Metadata for the policy set definition. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.parameters">parameters</a></code> | <code>{[ key: string ]: @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterDefinition}</code> | Parameter definitions for the policy set. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.policyDefinitionGroups">policyDefinitionGroups</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionGroup[]</code> | Groups for organizing policy definitions in the set. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.policyType">policyType</a></code> | <code>string</code> | The type of policy set definition. |
+
+---
+
+##### `connection`<sup>Optional</sup> <a name="connection" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.connection"></a>
+
+```typescript
+public readonly connection: SSHProvisionerConnection | WinrmProvisionerConnection;
+```
+
+- *Type:* cdktf.SSHProvisionerConnection | cdktf.WinrmProvisionerConnection
+
+---
+
+##### `count`<sup>Optional</sup> <a name="count" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.count"></a>
+
+```typescript
+public readonly count: number | TerraformCount;
+```
+
+- *Type:* number | cdktf.TerraformCount
+
+---
+
+##### `dependsOn`<sup>Optional</sup> <a name="dependsOn" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.dependsOn"></a>
+
+```typescript
+public readonly dependsOn: ITerraformDependable[];
+```
+
+- *Type:* cdktf.ITerraformDependable[]
+
+---
+
+##### `forEach`<sup>Optional</sup> <a name="forEach" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.forEach"></a>
+
+```typescript
+public readonly forEach: ITerraformIterator;
+```
+
+- *Type:* cdktf.ITerraformIterator
+
+---
+
+##### `lifecycle`<sup>Optional</sup> <a name="lifecycle" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.lifecycle"></a>
+
+```typescript
+public readonly lifecycle: TerraformResourceLifecycle;
+```
+
+- *Type:* cdktf.TerraformResourceLifecycle
+
+---
+
+##### `provider`<sup>Optional</sup> <a name="provider" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.provider"></a>
+
+```typescript
+public readonly provider: TerraformProvider;
+```
+
+- *Type:* cdktf.TerraformProvider
+
+---
+
+##### `provisioners`<sup>Optional</sup> <a name="provisioners" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.provisioners"></a>
+
+```typescript
+public readonly provisioners: (FileProvisioner | LocalExecProvisioner | RemoteExecProvisioner)[];
+```
+
+- *Type:* cdktf.FileProvisioner | cdktf.LocalExecProvisioner | cdktf.RemoteExecProvisioner[]
+
+---
+
+##### `apiVersion`<sup>Optional</sup> <a name="apiVersion" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.apiVersion"></a>
+
+```typescript
+public readonly apiVersion: string;
+```
+
+- *Type:* string
+- *Default:* Latest active version from ApiVersionManager
+
+Explicit API version to use for this resource.
+
+If not specified, the latest active version will be automatically resolved.
+Use this for version pinning when stability is required over latest features.
+
+---
+
+*Example*
+
+```typescript
+"2024-11-01"
+```
+
+
+##### `enableMigrationAnalysis`<sup>Optional</sup> <a name="enableMigrationAnalysis" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.enableMigrationAnalysis"></a>
+
+```typescript
+public readonly enableMigrationAnalysis: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Whether to enable migration analysis warnings.
+
+When true, the framework will analyze the current version for deprecation
+status and provide migration recommendations in the deployment output.
+
+---
+
+##### `enableTransformation`<sup>Optional</sup> <a name="enableTransformation" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.enableTransformation"></a>
+
+```typescript
+public readonly enableTransformation: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Whether to apply property transformations automatically.
+
+When true, properties will be automatically transformed according to the
+target schema's transformation rules. This enables backward compatibility.
+
+---
+
+##### `enableValidation`<sup>Optional</sup> <a name="enableValidation" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.enableValidation"></a>
+
+```typescript
+public readonly enableValidation: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Whether to validate properties against the schema.
+
+When true, all properties will be validated against the API schema before
+resource creation. Validation errors will cause deployment failures.
+
+---
+
+##### `location`<sup>Optional</sup> <a name="location" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.location"></a>
+
+```typescript
+public readonly location: string;
+```
+
+- *Type:* string
+- *Default:* Varies by resource type - see specific resource documentation
+
+The location where the resource should be created.
+
+---
+
+*Example*
+
+```typescript
+// Child resource (Subnet) - do not set location
+// location: undefined (inherited from parent Virtual Network)
+```
+
+
+##### `monitoring`<sup>Optional</sup> <a name="monitoring" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.monitoring"></a>
+
+```typescript
+public readonly monitoring: MonitoringConfig;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.core_azure.MonitoringConfig
+
+Monitoring configuration for this resource.
+
+Enables integrated monitoring with diagnostic settings, metric alerts,
+and activity log alerts. All monitoring is optional and disabled by default.
+
+---
+
+*Example*
+
+```typescript
+monitoring: {
+  enabled: true,
+  diagnosticSettings: {
+    workspaceId: logAnalytics.id,
+    metrics: ['AllMetrics'],
+    logs: ['AuditLogs']
+  },
+  metricAlerts: [{
+    name: 'high-cpu-alert',
+    severity: 2,
+    scopes: [], // Automatically set to this resource
+    criteria: { ... },
+    actions: [{ actionGroupId: actionGroup.id }]
+  }]
+}
+```
+
+
+##### `name`<sup>Optional</sup> <a name="name" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.name"></a>
+
+```typescript
+public readonly name: string;
+```
+
+- *Type:* string
+
+The name of the resource.
+
+---
+
+##### `tags`<sup>Optional</sup> <a name="tags" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.tags"></a>
+
+```typescript
+public readonly tags: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
+
+Tags to apply to the resource.
+
+---
+
+##### `displayName`<sup>Required</sup> <a name="displayName" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.displayName"></a>
+
+```typescript
+public readonly displayName: string;
+```
+
+- *Type:* string
+
+The display name of the policy set definition.
+
+This is the name shown in the Azure Portal.
+Required property.
+
+---
+
+*Example*
+
+```typescript
+"Security Baseline Initiative"
+```
+
+
+##### `policyDefinitions`<sup>Required</sup> <a name="policyDefinitions" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.policyDefinitions"></a>
+
+```typescript
+public readonly policyDefinitions: PolicyDefinitionReference[];
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionReference[]
+
+Array of policy definition references.
+
+Each reference specifies a policy definition to include in the set
+along with its parameter values and group memberships.
+Required property.
+
+---
+
+##### `scope`<sup>Required</sup> <a name="scope" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.scope"></a>
+
+```typescript
+public readonly scope: string;
+```
+
+- *Type:* string
+
+The scope at which to create the policy set definition.
+
+This can be:
+- A subscription: /subscriptions/{subscriptionId}
+- A management group: /providers/Microsoft.Management/managementGroups/{managementGroupId}
+
+---
+
+*Example*
+
+```typescript
+"/providers/Microsoft.Management/managementGroups/my-management-group"
+```
+
+
+##### `description`<sup>Optional</sup> <a name="description" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.description"></a>
+
+```typescript
+public readonly description: string;
+```
+
+- *Type:* string
+
+Description of the policy set definition.
+
+---
+
+*Example*
+
+```typescript
+"This initiative applies a set of security policies to ensure baseline compliance."
+```
+
+
+##### `metadata`<sup>Optional</sup> <a name="metadata" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.metadata"></a>
+
+```typescript
+public readonly metadata: PolicySetMetadata;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetMetadata
+
+Metadata for the policy set definition.
+
+Includes category, version, preview, and deprecated flags.
+
+---
+
+##### `parameters`<sup>Optional</sup> <a name="parameters" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.parameters"></a>
+
+```typescript
+public readonly parameters: {[ key: string ]: PolicySetParameterDefinition};
+```
+
+- *Type:* {[ key: string ]: @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterDefinition}
+
+Parameter definitions for the policy set.
+
+These parameters can be referenced by policy definitions in the set
+using the format: "[parameters('parameterName')]"
+
+---
+
+##### `policyDefinitionGroups`<sup>Optional</sup> <a name="policyDefinitionGroups" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.policyDefinitionGroups"></a>
+
+```typescript
+public readonly policyDefinitionGroups: PolicyDefinitionGroup[];
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicyDefinitionGroup[]
+
+Groups for organizing policy definitions in the set.
+
+Groups help categorize policies for management and compliance reporting.
+
+---
+
+##### `policyType`<sup>Optional</sup> <a name="policyType" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetDefinitionProps.property.policyType"></a>
+
+```typescript
+public readonly policyType: string;
+```
+
+- *Type:* string
+- *Default:* "Custom"
+
+The type of policy set definition.
+
+---
+
+### PolicySetMetadata <a name="PolicySetMetadata" id="@microsoft/terraform-cdk-constructs.PolicySetMetadata"></a>
+
+Metadata for the policy set definition.
+
+Metadata provides additional information about the policy set
+without affecting its evaluation logic.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.PolicySetMetadata.Initializer"></a>
+
+```typescript
+import { PolicySetMetadata } from '@microsoft/terraform-cdk-constructs'
+
+const policySetMetadata: PolicySetMetadata = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetMetadata.property.category">category</a></code> | <code>string</code> | The category of the policy set for Azure Portal organization. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetMetadata.property.deprecated">deprecated</a></code> | <code>boolean</code> | Whether this policy set is deprecated. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetMetadata.property.preview">preview</a></code> | <code>boolean</code> | Whether this policy set is in preview. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetMetadata.property.version">version</a></code> | <code>string</code> | The version of the policy set definition. |
+
+---
+
+##### `category`<sup>Optional</sup> <a name="category" id="@microsoft/terraform-cdk-constructs.PolicySetMetadata.property.category"></a>
+
+```typescript
+public readonly category: string;
+```
+
+- *Type:* string
+
+The category of the policy set for Azure Portal organization.
+
+---
+
+*Example*
+
+```typescript
+"Security Center"
+```
+
+
+##### `deprecated`<sup>Optional</sup> <a name="deprecated" id="@microsoft/terraform-cdk-constructs.PolicySetMetadata.property.deprecated"></a>
+
+```typescript
+public readonly deprecated: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Whether this policy set is deprecated.
+
+---
+
+##### `preview`<sup>Optional</sup> <a name="preview" id="@microsoft/terraform-cdk-constructs.PolicySetMetadata.property.preview"></a>
+
+```typescript
+public readonly preview: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Whether this policy set is in preview.
+
+---
+
+##### `version`<sup>Optional</sup> <a name="version" id="@microsoft/terraform-cdk-constructs.PolicySetMetadata.property.version"></a>
+
+```typescript
+public readonly version: string;
+```
+
+- *Type:* string
+
+The version of the policy set definition.
+
+---
+
+*Example*
+
+```typescript
+"1.0.0"
+```
+
+
+### PolicySetMetadata <a name="PolicySetMetadata" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetMetadata"></a>
+
+Metadata for the policy set definition.
+
+Metadata provides additional information about the policy set
+without affecting its evaluation logic.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetMetadata.Initializer"></a>
+
+```typescript
+import { azure_policysetdefinition } from '@microsoft/terraform-cdk-constructs'
+
+const policySetMetadata: azure_policysetdefinition.PolicySetMetadata = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetMetadata.property.category">category</a></code> | <code>string</code> | The category of the policy set for Azure Portal organization. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetMetadata.property.deprecated">deprecated</a></code> | <code>boolean</code> | Whether this policy set is deprecated. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetMetadata.property.preview">preview</a></code> | <code>boolean</code> | Whether this policy set is in preview. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetMetadata.property.version">version</a></code> | <code>string</code> | The version of the policy set definition. |
+
+---
+
+##### `category`<sup>Optional</sup> <a name="category" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetMetadata.property.category"></a>
+
+```typescript
+public readonly category: string;
+```
+
+- *Type:* string
+
+The category of the policy set for Azure Portal organization.
+
+---
+
+*Example*
+
+```typescript
+"Security Center"
+```
+
+
+##### `deprecated`<sup>Optional</sup> <a name="deprecated" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetMetadata.property.deprecated"></a>
+
+```typescript
+public readonly deprecated: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Whether this policy set is deprecated.
+
+---
+
+##### `preview`<sup>Optional</sup> <a name="preview" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetMetadata.property.preview"></a>
+
+```typescript
+public readonly preview: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Whether this policy set is in preview.
+
+---
+
+##### `version`<sup>Optional</sup> <a name="version" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetMetadata.property.version"></a>
+
+```typescript
+public readonly version: string;
+```
+
+- *Type:* string
+
+The version of the policy set definition.
+
+---
+
+*Example*
+
+```typescript
+"1.0.0"
+```
+
+
+### PolicySetParameterDefinition <a name="PolicySetParameterDefinition" id="@microsoft/terraform-cdk-constructs.PolicySetParameterDefinition"></a>
+
+Parameter definition for the policy set.
+
+These parameters can be referenced by policy definitions within the set.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.PolicySetParameterDefinition.Initializer"></a>
+
+```typescript
+import { PolicySetParameterDefinition } from '@microsoft/terraform-cdk-constructs'
+
+const policySetParameterDefinition: PolicySetParameterDefinition = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetParameterDefinition.property.type">type</a></code> | <code>string</code> | The data type of the parameter. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetParameterDefinition.property.allowedValues">allowedValues</a></code> | <code>any[]</code> | Allowed values for the parameter. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetParameterDefinition.property.defaultValue">defaultValue</a></code> | <code>any</code> | Default value for the parameter. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetParameterDefinition.property.description">description</a></code> | <code>string</code> | Description of the parameter. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetParameterDefinition.property.displayName">displayName</a></code> | <code>string</code> | Display name for the parameter in Azure Portal. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetParameterDefinition.property.metadata">metadata</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterMetadata</code> | Metadata for the parameter (e.g., strongType for Azure Portal integration). |
+
+---
+
+##### `type`<sup>Required</sup> <a name="type" id="@microsoft/terraform-cdk-constructs.PolicySetParameterDefinition.property.type"></a>
+
+```typescript
+public readonly type: string;
+```
+
+- *Type:* string
+
+The data type of the parameter.
+
+---
+
+##### `allowedValues`<sup>Optional</sup> <a name="allowedValues" id="@microsoft/terraform-cdk-constructs.PolicySetParameterDefinition.property.allowedValues"></a>
+
+```typescript
+public readonly allowedValues: any[];
+```
+
+- *Type:* any[]
+
+Allowed values for the parameter.
+
+---
+
+##### `defaultValue`<sup>Optional</sup> <a name="defaultValue" id="@microsoft/terraform-cdk-constructs.PolicySetParameterDefinition.property.defaultValue"></a>
+
+```typescript
+public readonly defaultValue: any;
+```
+
+- *Type:* any
+
+Default value for the parameter.
+
+---
+
+##### `description`<sup>Optional</sup> <a name="description" id="@microsoft/terraform-cdk-constructs.PolicySetParameterDefinition.property.description"></a>
+
+```typescript
+public readonly description: string;
+```
+
+- *Type:* string
+
+Description of the parameter.
+
+---
+
+##### `displayName`<sup>Optional</sup> <a name="displayName" id="@microsoft/terraform-cdk-constructs.PolicySetParameterDefinition.property.displayName"></a>
+
+```typescript
+public readonly displayName: string;
+```
+
+- *Type:* string
+
+Display name for the parameter in Azure Portal.
+
+---
+
+##### `metadata`<sup>Optional</sup> <a name="metadata" id="@microsoft/terraform-cdk-constructs.PolicySetParameterDefinition.property.metadata"></a>
+
+```typescript
+public readonly metadata: PolicySetParameterMetadata;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterMetadata
+
+Metadata for the parameter (e.g., strongType for Azure Portal integration).
+
+---
+
+### PolicySetParameterDefinition <a name="PolicySetParameterDefinition" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterDefinition"></a>
+
+Parameter definition for the policy set.
+
+These parameters can be referenced by policy definitions within the set.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterDefinition.Initializer"></a>
+
+```typescript
+import { azure_policysetdefinition } from '@microsoft/terraform-cdk-constructs'
+
+const policySetParameterDefinition: azure_policysetdefinition.PolicySetParameterDefinition = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterDefinition.property.type">type</a></code> | <code>string</code> | The data type of the parameter. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterDefinition.property.allowedValues">allowedValues</a></code> | <code>any[]</code> | Allowed values for the parameter. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterDefinition.property.defaultValue">defaultValue</a></code> | <code>any</code> | Default value for the parameter. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterDefinition.property.description">description</a></code> | <code>string</code> | Description of the parameter. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterDefinition.property.displayName">displayName</a></code> | <code>string</code> | Display name for the parameter in Azure Portal. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterDefinition.property.metadata">metadata</a></code> | <code>@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterMetadata</code> | Metadata for the parameter (e.g., strongType for Azure Portal integration). |
+
+---
+
+##### `type`<sup>Required</sup> <a name="type" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterDefinition.property.type"></a>
+
+```typescript
+public readonly type: string;
+```
+
+- *Type:* string
+
+The data type of the parameter.
+
+---
+
+##### `allowedValues`<sup>Optional</sup> <a name="allowedValues" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterDefinition.property.allowedValues"></a>
+
+```typescript
+public readonly allowedValues: any[];
+```
+
+- *Type:* any[]
+
+Allowed values for the parameter.
+
+---
+
+##### `defaultValue`<sup>Optional</sup> <a name="defaultValue" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterDefinition.property.defaultValue"></a>
+
+```typescript
+public readonly defaultValue: any;
+```
+
+- *Type:* any
+
+Default value for the parameter.
+
+---
+
+##### `description`<sup>Optional</sup> <a name="description" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterDefinition.property.description"></a>
+
+```typescript
+public readonly description: string;
+```
+
+- *Type:* string
+
+Description of the parameter.
+
+---
+
+##### `displayName`<sup>Optional</sup> <a name="displayName" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterDefinition.property.displayName"></a>
+
+```typescript
+public readonly displayName: string;
+```
+
+- *Type:* string
+
+Display name for the parameter in Azure Portal.
+
+---
+
+##### `metadata`<sup>Optional</sup> <a name="metadata" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterDefinition.property.metadata"></a>
+
+```typescript
+public readonly metadata: PolicySetParameterMetadata;
+```
+
+- *Type:* @microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterMetadata
+
+Metadata for the parameter (e.g., strongType for Azure Portal integration).
+
+---
+
+### PolicySetParameterMetadata <a name="PolicySetParameterMetadata" id="@microsoft/terraform-cdk-constructs.PolicySetParameterMetadata"></a>
+
+Metadata for a policy set parameter.
+
+Provides additional information for Azure Portal integration.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.PolicySetParameterMetadata.Initializer"></a>
+
+```typescript
+import { PolicySetParameterMetadata } from '@microsoft/terraform-cdk-constructs'
+
+const policySetParameterMetadata: PolicySetParameterMetadata = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetParameterMetadata.property.description">description</a></code> | <code>string</code> | Description in Azure Portal. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetParameterMetadata.property.displayName">displayName</a></code> | <code>string</code> | Display name in Azure Portal. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.PolicySetParameterMetadata.property.strongType">strongType</a></code> | <code>string</code> | Strong type for Azure Portal resource picker integration. |
+
+---
+
+##### `description`<sup>Optional</sup> <a name="description" id="@microsoft/terraform-cdk-constructs.PolicySetParameterMetadata.property.description"></a>
+
+```typescript
+public readonly description: string;
+```
+
+- *Type:* string
+
+Description in Azure Portal.
+
+---
+
+##### `displayName`<sup>Optional</sup> <a name="displayName" id="@microsoft/terraform-cdk-constructs.PolicySetParameterMetadata.property.displayName"></a>
+
+```typescript
+public readonly displayName: string;
+```
+
+- *Type:* string
+
+Display name in Azure Portal.
+
+---
+
+##### `strongType`<sup>Optional</sup> <a name="strongType" id="@microsoft/terraform-cdk-constructs.PolicySetParameterMetadata.property.strongType"></a>
+
+```typescript
+public readonly strongType: string;
+```
+
+- *Type:* string
+
+Strong type for Azure Portal resource picker integration.
+
+---
+
+### PolicySetParameterMetadata <a name="PolicySetParameterMetadata" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterMetadata"></a>
+
+Metadata for a policy set parameter.
+
+Provides additional information for Azure Portal integration.
+
+#### Initializer <a name="Initializer" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterMetadata.Initializer"></a>
+
+```typescript
+import { azure_policysetdefinition } from '@microsoft/terraform-cdk-constructs'
+
+const policySetParameterMetadata: azure_policysetdefinition.PolicySetParameterMetadata = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterMetadata.property.description">description</a></code> | <code>string</code> | Description in Azure Portal. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterMetadata.property.displayName">displayName</a></code> | <code>string</code> | Display name in Azure Portal. |
+| <code><a href="#@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterMetadata.property.strongType">strongType</a></code> | <code>string</code> | Strong type for Azure Portal resource picker integration. |
+
+---
+
+##### `description`<sup>Optional</sup> <a name="description" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterMetadata.property.description"></a>
+
+```typescript
+public readonly description: string;
+```
+
+- *Type:* string
+
+Description in Azure Portal.
+
+---
+
+##### `displayName`<sup>Optional</sup> <a name="displayName" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterMetadata.property.displayName"></a>
+
+```typescript
+public readonly displayName: string;
+```
+
+- *Type:* string
+
+Display name in Azure Portal.
+
+---
+
+##### `strongType`<sup>Optional</sup> <a name="strongType" id="@microsoft/terraform-cdk-constructs.azure_policysetdefinition.PolicySetParameterMetadata.property.strongType"></a>
+
+```typescript
+public readonly strongType: string;
+```
+
+- *Type:* string
+
+Strong type for Azure Portal resource picker integration.
+
+---
 
 ### PrivateDnsAaaaRecordProps <a name="PrivateDnsAaaaRecordProps" id="@microsoft/terraform-cdk-constructs.PrivateDnsAaaaRecordProps"></a>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,13 +7,19 @@
     "": {
       "name": "@microsoft/terraform-cdk-constructs",
       "version": "0.0.0",
+      "bundleDependencies": [
+        "uuid"
+      ],
       "license": "MIT",
       "dependencies": {
-        "cdktf": "0.20.8"
+        "cdktf": "0.20.8",
+        "glob": "^13.0.6",
+        "uuid": "^11.0.3"
       },
       "devDependencies": {
         "@types/jest": "^29",
         "@types/node": "^20",
+        "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^6",
         "@typescript-eslint/parser": "^6",
         "cdktf": "0.20.8",
@@ -954,6 +960,28 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@jest/reporters/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -1441,6 +1469,13 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2754,8 +2789,6 @@
     },
     "node_modules/cdktf/node_modules/lazystream/node_modules/readable-stream": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5072,21 +5105,17 @@
       "license": "ISC"
     },
     "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "license": "ISC",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -5103,6 +5132,42 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -6040,6 +6105,28 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/jest-config/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/jest-diff": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
@@ -6174,6 +6261,16 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/jest-junit/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/jest-leak-detector": {
@@ -6400,6 +6497,28 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/jest-runtime/node_modules/strip-bom": {
@@ -7659,6 +7778,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -8035,6 +8163,31 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/path-type": {
       "version": "3.0.0",
@@ -8555,8 +8708,6 @@
     },
     "node_modules/projen/node_modules/glob/node_modules/minimatch": {
       "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8699,8 +8850,6 @@
     },
     "node_modules/projen/node_modules/minimatch/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8839,8 +8988,6 @@
     },
     "node_modules/projen/node_modules/shelljs/node_modules/glob": {
       "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9034,8 +9181,6 @@
     },
     "node_modules/projen/node_modules/yargs/node_modules/yargs-parser": {
       "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9382,6 +9527,28 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -10232,6 +10399,28 @@
         "node": ">=8"
       }
     },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/text-extensions": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
@@ -10684,13 +10873,17 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "inBundle": true,
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/src/azure-loganalyticsworkspace/README.md
+++ b/src/azure-loganalyticsworkspace/README.md
@@ -1,0 +1,369 @@
+# Azure Log Analytics Workspace Construct
+
+This module provides a high-level TypeScript construct for managing Azure Log Analytics Workspaces using the Terraform CDK and Azure AZAPI provider.
+
+## Features
+
+- **Multiple API Version Support**: Supports 2023-09-01 (latest) and 2022-10-01 (for backward compatibility)
+- **Automatic Version Resolution**: Uses the latest API version by default
+- **Version Pinning**: Lock to a specific API version for stability
+- **Type-Safe**: Full TypeScript support with comprehensive interfaces
+- **JSII Compatible**: Can be used from TypeScript, Python, Java, and C#
+- **Terraform Outputs**: Automatic creation of outputs for id, name, workspaceId, and customerId
+- **Tag Management**: Built-in methods for managing resource tags
+
+## Supported API Versions
+
+| Version | Status | Release Date | Notes |
+|---------|--------|--------------|-------|
+| 2023-09-01 | Active (Latest) | 2023-09-01 | Recommended for new deployments, includes Data Collection Rule support |
+| 2022-10-01 | Active | 2022-10-01 | Stable release for backward compatibility |
+
+## Installation
+
+This module is part of the `@microsoft/terraform-cdk-constructs` package.
+
+```bash
+npm install @microsoft/terraform-cdk-constructs
+```
+
+## Basic Usage
+
+### Simple Log Analytics Workspace
+
+```typescript
+import { App, TerraformStack } from "cdktf";
+import { AzapiProvider } from "@microsoft/terraform-cdk-constructs/core-azure";
+import { ResourceGroup } from "@microsoft/terraform-cdk-constructs/azure-resourcegroup";
+import { LogAnalyticsWorkspace } from "@microsoft/terraform-cdk-constructs/azure-loganalyticsworkspace";
+
+const app = new App();
+const stack = new TerraformStack(app, "log-analytics-stack");
+
+// Configure the Azure provider
+new AzapiProvider(stack, "azapi", {});
+
+// Create a resource group
+const resourceGroup = new ResourceGroup(stack, "rg", {
+  name: "my-resource-group",
+  location: "eastus",
+});
+
+// Create a Log Analytics Workspace
+const workspace = new LogAnalyticsWorkspace(stack, "workspace", {
+  name: "my-log-analytics",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  tags: {
+    environment: "production",
+    project: "monitoring",
+  },
+});
+
+app.synth();
+```
+
+## Advanced Usage
+
+### Custom Retention Period
+
+```typescript
+const workspace = new LogAnalyticsWorkspace(stack, "workspace-retention", {
+  name: "workspace-with-retention",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  retentionInDays: 90, // Keep data for 90 days (range: 30-730)
+});
+```
+
+### PerGB2018 Pricing (Pay-as-you-go)
+
+```typescript
+const workspace = new LogAnalyticsWorkspace(stack, "workspace-pergb", {
+  name: "workspace-pergb",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  sku: {
+    name: "PerGB2018",
+  },
+  retentionInDays: 60,
+});
+```
+
+### Capacity Reservation Pricing
+
+```typescript
+const workspace = new LogAnalyticsWorkspace(stack, "workspace-capacity", {
+  name: "workspace-capacity-reservation",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  sku: {
+    name: "CapacityReservation",
+    capacityReservationLevel: 500, // Valid values: 100, 200, 300, 400, 500, 1000, 2000, 5000
+  },
+  retentionInDays: 365,
+});
+```
+
+### Daily Volume Cap (Workspace Capping)
+
+```typescript
+const workspace = new LogAnalyticsWorkspace(stack, "workspace-capped", {
+  name: "workspace-with-cap",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  workspaceCapping: {
+    dailyQuotaGb: 100, // Stop ingestion after 100GB per day
+  },
+});
+```
+
+### Private Network Access
+
+```typescript
+const workspace = new LogAnalyticsWorkspace(stack, "workspace-private", {
+  name: "workspace-private",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  publicNetworkAccessForIngestion: "Disabled",
+  publicNetworkAccessForQuery: "Disabled",
+});
+```
+
+### Workspace Features
+
+```typescript
+const workspace = new LogAnalyticsWorkspace(stack, "workspace-features", {
+  name: "workspace-with-features",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  features: {
+    enableDataExport: true,
+    immediatePurgeDataOn30Days: false,
+    disableLocalAuth: true,
+    enableLogAccessUsingOnlyResourcePermissions: true,
+  },
+});
+```
+
+### Managed Identity
+
+```typescript
+const workspace = new LogAnalyticsWorkspace(stack, "workspace-identity", {
+  name: "workspace-with-identity",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  identity: {
+    type: "SystemAssigned",
+  },
+});
+```
+
+### Pinning to a Specific API Version
+
+```typescript
+const workspace = new LogAnalyticsWorkspace(stack, "workspace-pinned", {
+  name: "workspace-stable",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  apiVersion: "2022-10-01", // Pin to specific version
+});
+```
+
+### Using Outputs
+
+```typescript
+const workspace = new LogAnalyticsWorkspace(stack, "workspace", {
+  name: "my-workspace",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+});
+
+// Access workspace ID for use in other resources (e.g., Diagnostic Settings)
+console.log(workspace.id); // Terraform interpolation string
+
+// Use outputs for cross-stack references
+new TerraformOutput(stack, "workspace-id", {
+  value: workspace.idOutput,
+});
+
+new TerraformOutput(stack, "workspace-customer-id", {
+  value: workspace.customerIdOutput,
+});
+```
+
+## API Reference
+
+### LogAnalyticsWorkspaceProps
+
+Configuration properties for the Log Analytics Workspace construct.
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `name` | `string` | No* | Name of the workspace. If not provided, uses the construct ID. Must be 4-63 characters, alphanumeric and hyphens. |
+| `location` | `string` | Yes | Azure region where the workspace will be created. |
+| `resourceGroupId` | `string` | Yes | Resource group ID where the workspace will be created. |
+| `retentionInDays` | `number` | No | Data retention in days (30-730). Default: 30. |
+| `sku` | `LogAnalyticsWorkspaceSku` | No | SKU configuration. Default: { name: "PerGB2018" }. |
+| `workspaceCapping` | `LogAnalyticsWorkspaceCapping` | No | Daily volume cap configuration. |
+| `publicNetworkAccessForIngestion` | `"Enabled" \| "Disabled"` | No | Network access for data ingestion. Default: "Enabled". |
+| `publicNetworkAccessForQuery` | `"Enabled" \| "Disabled"` | No | Network access for queries. Default: "Enabled". |
+| `features` | `LogAnalyticsWorkspaceFeatures` | No | Workspace feature flags. |
+| `forceCmkForQuery` | `boolean` | No | Require customer-managed keys for saved searches/alerts. |
+| `defaultDataCollectionRuleResourceId` | `string` | No | Default DCR resource ID (API 2023-09-01+). |
+| `identity` | `LogAnalyticsWorkspaceIdentity` | No | Managed identity configuration. |
+| `tags` | `{ [key: string]: string }` | No | Resource tags. |
+| `apiVersion` | `string` | No | Pin to a specific API version. |
+
+### LogAnalyticsWorkspaceSku
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `name` | `string` | Yes | SKU name: "Free", "Standard", "Premium", "PerNode", "PerGB2018", "Standalone", "CapacityReservation" |
+| `capacityReservationLevel` | `number` | No | Capacity in GB/day for CapacityReservation SKU. Valid: 100, 200, 300, 400, 500, 1000, 2000, 5000. |
+
+### LogAnalyticsWorkspaceCapping
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `dailyQuotaGb` | `number` | Yes | Daily volume cap in GB. Use -1 for no cap. |
+
+### LogAnalyticsWorkspaceFeatures
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `enableDataExport` | `boolean` | No | Enable data export capability. |
+| `immediatePurgeDataOn30Days` | `boolean` | No | Purge data immediately after 30 days. |
+| `disableLocalAuth` | `boolean` | No | Disable local authentication. |
+| `enableLogAccessUsingOnlyResourcePermissions` | `boolean` | No | Enable resource-based access only. |
+
+### LogAnalyticsWorkspaceIdentity
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `type` | `string` | Yes | Identity type: "SystemAssigned", "UserAssigned", "SystemAssigned,UserAssigned", "None" |
+| `userAssignedIdentities` | `object` | No | User-assigned identity resource IDs. |
+
+### Public Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `string` | The Azure resource ID of the workspace. |
+| `props` | `LogAnalyticsWorkspaceProps` | The original input properties. |
+| `resolvedApiVersion` | `string` | The API version being used. |
+
+### Outputs
+
+The construct automatically creates Terraform outputs:
+
+- `id`: The workspace resource ID
+- `name`: The workspace name
+- `workspace_id`: The workspace unique identifier (GUID)
+- `customer_id`: The workspace customer ID (same as workspace_id)
+
+### Methods
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| `addTag` | `key: string, value: string` | Add a tag to the workspace. |
+| `addAccess` | `objectId: string, roleDefinitionName: string` | Add RBAC role assignment. |
+
+## Best Practices
+
+### 1. Use PerGB2018 for Most Workloads
+
+Unless you have specific requirements, the pay-as-you-go model is most cost-effective:
+
+```typescript
+const workspace = new LogAnalyticsWorkspace(stack, "workspace", {
+  name: "my-workspace",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  sku: { name: "PerGB2018" },
+});
+```
+
+### 2. Set Appropriate Retention
+
+Balance between compliance requirements and cost:
+
+```typescript
+// Production: longer retention for compliance
+const prodWorkspace = new LogAnalyticsWorkspace(stack, "prod-workspace", {
+  name: "prod-logs",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  retentionInDays: 365,
+});
+
+// Development: shorter retention to save costs
+const devWorkspace = new LogAnalyticsWorkspace(stack, "dev-workspace", {
+  name: "dev-logs", 
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  retentionInDays: 30,
+});
+```
+
+### 3. Use Daily Cap for Cost Control
+
+Prevent unexpected charges from log spikes:
+
+```typescript
+const workspace = new LogAnalyticsWorkspace(stack, "workspace", {
+  name: "cost-controlled",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  workspaceCapping: {
+    dailyQuotaGb: 50, // Stop at 50GB/day
+  },
+});
+```
+
+### 4. Apply Consistent Tags
+
+```typescript
+const workspace = new LogAnalyticsWorkspace(stack, "workspace", {
+  name: "my-workspace",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  tags: {
+    environment: "production",
+    "cost-center": "platform-team",
+    "managed-by": "terraform",
+  },
+});
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Retention Out of Range**: Ensure `retentionInDays` is between 30 and 730.
+
+2. **Invalid Capacity Reservation Level**: Valid values are 100, 200, 300, 400, 500, 1000, 2000, 5000.
+
+3. **Name Validation**: Workspace names must be 4-63 characters, start and end with alphanumeric, and contain only letters, numbers, and hyphens.
+
+4. **API Version Errors**: Ensure the version is 2023-09-01 or 2022-10-01.
+
+## Related Constructs
+
+- [`ResourceGroup`](../azure-resourcegroup/README.md) - Azure Resource Groups
+- [`DiagnosticSettings`](../azure-diagnosticsettings/README.md) - Send logs to this workspace
+- [`MetricAlert`](../azure-metricalert/README.md) - Create alerts based on workspace metrics
+
+## Additional Resources
+
+- [Azure Log Analytics Documentation](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overview)
+- [Log Analytics Pricing](https://azure.microsoft.com/en-us/pricing/details/monitor/)
+- [Azure REST API Reference](https://learn.microsoft.com/en-us/rest/api/loganalytics/)
+- [Terraform CDK Documentation](https://developer.hashicorp.com/terraform/cdktf)
+
+## Contributing
+
+Contributions are welcome! Please see the [Contributing Guide](../../CONTRIBUTING.md) for details.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](../../LICENSE) file for details.

--- a/src/azure-loganalyticsworkspace/index.ts
+++ b/src/azure-loganalyticsworkspace/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Azure Log Analytics Workspace module
+ *
+ * This module provides constructs for creating and managing Azure Log Analytics Workspaces.
+ */
+
+export * from "./lib";

--- a/src/azure-loganalyticsworkspace/lib/index.ts
+++ b/src/azure-loganalyticsworkspace/lib/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Azure Log Analytics Workspace construct exports
+ */
+
+export * from "./log-analytics-workspace-schemas";
+export * from "./log-analytics-workspace";

--- a/src/azure-loganalyticsworkspace/lib/log-analytics-workspace-schemas.ts
+++ b/src/azure-loganalyticsworkspace/lib/log-analytics-workspace-schemas.ts
@@ -1,0 +1,282 @@
+/**
+ * API schemas for Azure Log Analytics Workspace across all supported versions
+ *
+ * This file defines the complete API schemas for Microsoft.OperationalInsights/workspaces
+ * across all supported API versions. The schemas are used by the AzapiResource
+ * framework for validation, transformation, and version management.
+ */
+
+import {
+  ApiSchema,
+  PropertyDefinition,
+  PropertyType,
+  ValidationRuleType,
+  VersionConfig,
+  VersionSupportLevel,
+} from "../../core-azure/lib/version-manager/interfaces/version-interfaces";
+
+// =============================================================================
+// COMMON PROPERTY DEFINITIONS
+// =============================================================================
+
+/**
+ * Common property definitions shared across all Log Analytics Workspace versions
+ */
+const COMMON_LOG_ANALYTICS_WORKSPACE_PROPERTIES: {
+  [key: string]: PropertyDefinition;
+} = {
+  name: {
+    dataType: PropertyType.STRING,
+    required: true,
+    description: "Name of the Log Analytics workspace",
+    validation: [
+      {
+        ruleType: ValidationRuleType.REQUIRED,
+        message: "Name is required",
+      },
+      {
+        ruleType: ValidationRuleType.PATTERN_MATCH,
+        value: "^[a-zA-Z0-9][a-zA-Z0-9-]{2,61}[a-zA-Z0-9]$",
+        message:
+          "Workspace name must be 4-63 characters, start and end with a letter or number, and contain only letters, numbers, and hyphens",
+      },
+    ],
+  },
+  location: {
+    dataType: PropertyType.STRING,
+    required: true,
+    description: "Azure region where the workspace will be created",
+  },
+  retentionInDays: {
+    dataType: PropertyType.NUMBER,
+    required: false,
+    defaultValue: 30,
+    description:
+      "Data retention in days. Values between 30 and 730 are allowed. Default is 30 days.",
+    validation: [
+      {
+        ruleType: ValidationRuleType.VALUE_RANGE,
+        value: { min: 30, max: 730 },
+        message: "Retention must be between 30 and 730 days",
+      },
+    ],
+  },
+  sku: {
+    dataType: PropertyType.OBJECT,
+    required: false,
+    description:
+      "SKU configuration for the workspace. Options: Free, Standard, Premium, PerNode, PerGB2018, Standalone, CapacityReservation",
+  },
+  workspaceCapping: {
+    dataType: PropertyType.OBJECT,
+    required: false,
+    description: "Daily volume cap for data ingestion in GB",
+  },
+  publicNetworkAccessForIngestion: {
+    dataType: PropertyType.STRING,
+    required: false,
+    description:
+      "Public network access for data ingestion: Enabled or Disabled",
+  },
+  publicNetworkAccessForQuery: {
+    dataType: PropertyType.STRING,
+    required: false,
+    description: "Public network access for queries: Enabled or Disabled",
+  },
+  features: {
+    dataType: PropertyType.OBJECT,
+    required: false,
+    description:
+      "Workspace features like enableDataExport, immediatePurgeDataOn30Days, etc.",
+  },
+  forceCmkForQuery: {
+    dataType: PropertyType.BOOLEAN,
+    required: false,
+    description:
+      "Whether customer-managed keys are required for saved searches and alerts",
+  },
+  defaultDataCollectionRuleResourceId: {
+    dataType: PropertyType.STRING,
+    required: false,
+    description: "Resource ID of the default Data Collection Rule",
+    addedInVersion: "2023-09-01",
+  },
+  identity: {
+    dataType: PropertyType.OBJECT,
+    required: false,
+    description: "Managed identity configuration for the workspace",
+  },
+};
+
+// =============================================================================
+// VERSION-SPECIFIC SCHEMAS
+// =============================================================================
+
+/**
+ * API Schema for Log Analytics Workspace version 2023-09-01
+ *
+ * This is the latest stable version for Log Analytics Workspace.
+ * It includes support for:
+ * - Data retention configuration
+ * - SKU management (Free, PerGB2018, CapacityReservation, etc.)
+ * - Daily volume cap (workspace capping)
+ * - Public network access controls
+ * - Workspace features (enableDataExport, immediatePurgeDataOn30Days, etc.)
+ * - Default Data Collection Rule
+ * - Managed identity
+ */
+export const LOG_ANALYTICS_WORKSPACE_SCHEMA_2023_09_01: ApiSchema = {
+  resourceType: "Microsoft.OperationalInsights/workspaces",
+  version: "2023-09-01",
+  properties: {
+    ...COMMON_LOG_ANALYTICS_WORKSPACE_PROPERTIES,
+  },
+  required: ["name", "location"],
+  optional: [
+    "retentionInDays",
+    "sku",
+    "workspaceCapping",
+    "publicNetworkAccessForIngestion",
+    "publicNetworkAccessForQuery",
+    "features",
+    "forceCmkForQuery",
+    "defaultDataCollectionRuleResourceId",
+    "identity",
+  ],
+  deprecated: [],
+  transformationRules: {},
+  validationRules: [
+    {
+      property: "name",
+      rules: [
+        {
+          ruleType: ValidationRuleType.REQUIRED,
+          message: "Name is required for Log Analytics Workspace",
+        },
+      ],
+    },
+  ],
+};
+
+/**
+ * API Schema for Log Analytics Workspace version 2022-10-01
+ *
+ * This is a stable version for backward compatibility.
+ * It includes support for:
+ * - Data retention configuration
+ * - SKU management
+ * - Daily volume cap
+ * - Public network access controls
+ * - Workspace features
+ */
+export const LOG_ANALYTICS_WORKSPACE_SCHEMA_2022_10_01: ApiSchema = {
+  resourceType: "Microsoft.OperationalInsights/workspaces",
+  version: "2022-10-01",
+  properties: {
+    name: COMMON_LOG_ANALYTICS_WORKSPACE_PROPERTIES.name,
+    location: COMMON_LOG_ANALYTICS_WORKSPACE_PROPERTIES.location,
+    retentionInDays: COMMON_LOG_ANALYTICS_WORKSPACE_PROPERTIES.retentionInDays,
+    sku: COMMON_LOG_ANALYTICS_WORKSPACE_PROPERTIES.sku,
+    workspaceCapping:
+      COMMON_LOG_ANALYTICS_WORKSPACE_PROPERTIES.workspaceCapping,
+    publicNetworkAccessForIngestion:
+      COMMON_LOG_ANALYTICS_WORKSPACE_PROPERTIES.publicNetworkAccessForIngestion,
+    publicNetworkAccessForQuery:
+      COMMON_LOG_ANALYTICS_WORKSPACE_PROPERTIES.publicNetworkAccessForQuery,
+    features: COMMON_LOG_ANALYTICS_WORKSPACE_PROPERTIES.features,
+    forceCmkForQuery:
+      COMMON_LOG_ANALYTICS_WORKSPACE_PROPERTIES.forceCmkForQuery,
+    identity: COMMON_LOG_ANALYTICS_WORKSPACE_PROPERTIES.identity,
+    // Note: defaultDataCollectionRuleResourceId is not available in this version
+  },
+  required: ["name", "location"],
+  optional: [
+    "retentionInDays",
+    "sku",
+    "workspaceCapping",
+    "publicNetworkAccessForIngestion",
+    "publicNetworkAccessForQuery",
+    "features",
+    "forceCmkForQuery",
+    "identity",
+  ],
+  deprecated: [],
+  transformationRules: {},
+  validationRules: [
+    {
+      property: "name",
+      rules: [
+        {
+          ruleType: ValidationRuleType.REQUIRED,
+          message: "Name is required for Log Analytics Workspace",
+        },
+      ],
+    },
+  ],
+};
+
+// =============================================================================
+// VERSION CONFIGURATIONS
+// =============================================================================
+
+/**
+ * Version configuration for Log Analytics Workspace 2023-09-01
+ */
+export const LOG_ANALYTICS_WORKSPACE_VERSION_2023_09_01: VersionConfig = {
+  version: "2023-09-01",
+  schema: LOG_ANALYTICS_WORKSPACE_SCHEMA_2023_09_01,
+  supportLevel: VersionSupportLevel.ACTIVE,
+  releaseDate: "2023-09-01",
+  deprecationDate: undefined,
+  sunsetDate: undefined,
+  breakingChanges: [],
+  migrationGuide: "/docs/log-analytics-workspace/migration-2023-09-01",
+  changeLog: [
+    {
+      changeType: "added",
+      description: "Added support for default Data Collection Rule resource ID",
+      breaking: false,
+    },
+    {
+      changeType: "updated",
+      description: "Latest stable API version with enhanced feature support",
+      breaking: false,
+    },
+  ],
+};
+
+/**
+ * Version configuration for Log Analytics Workspace 2022-10-01
+ */
+export const LOG_ANALYTICS_WORKSPACE_VERSION_2022_10_01: VersionConfig = {
+  version: "2022-10-01",
+  schema: LOG_ANALYTICS_WORKSPACE_SCHEMA_2022_10_01,
+  supportLevel: VersionSupportLevel.ACTIVE,
+  releaseDate: "2022-10-01",
+  deprecationDate: undefined,
+  sunsetDate: undefined,
+  breakingChanges: [],
+  migrationGuide: "/docs/log-analytics-workspace/migration-2022-10-01",
+  changeLog: [
+    {
+      changeType: "updated",
+      description: "Stable API version for backward compatibility",
+      breaking: false,
+    },
+  ],
+};
+
+/**
+ * All supported Log Analytics Workspace versions for registration
+ * Ordered with latest stable version first
+ */
+export const ALL_LOG_ANALYTICS_WORKSPACE_VERSIONS: VersionConfig[] = [
+  LOG_ANALYTICS_WORKSPACE_VERSION_2023_09_01,
+  LOG_ANALYTICS_WORKSPACE_VERSION_2022_10_01,
+];
+
+/**
+ * Resource type constant
+ */
+export const LOG_ANALYTICS_WORKSPACE_TYPE =
+  "Microsoft.OperationalInsights/workspaces";

--- a/src/azure-loganalyticsworkspace/lib/log-analytics-workspace.ts
+++ b/src/azure-loganalyticsworkspace/lib/log-analytics-workspace.ts
@@ -1,0 +1,461 @@
+/**
+ * Unified Azure Log Analytics Workspace implementation using AzapiResource framework
+ *
+ * This class provides a version-aware implementation for Azure Log Analytics Workspace
+ * that automatically handles version management, schema validation, and property
+ * transformation across all supported API versions.
+ *
+ * Supported API Versions:
+ * - 2023-09-01 (Active, Latest)
+ * - 2022-10-01 (Active, Backward Compatibility)
+ *
+ * Features:
+ * - Automatic latest version resolution when no version is specified
+ * - Explicit version pinning for stability requirements
+ * - Schema-driven validation and transformation
+ * - Full JSII compliance for multi-language support
+ * - Configurable data retention, SKU, and workspace capping
+ * - Public network access controls
+ * - Workspace features configuration
+ */
+
+import * as cdktf from "cdktf";
+import { Construct } from "constructs";
+import {
+  ALL_LOG_ANALYTICS_WORKSPACE_VERSIONS,
+  LOG_ANALYTICS_WORKSPACE_TYPE,
+} from "./log-analytics-workspace-schemas";
+import {
+  AzapiResource,
+  AzapiResourceProps,
+} from "../../core-azure/lib/azapi/azapi-resource";
+import { ApiSchema } from "../../core-azure/lib/version-manager/interfaces/version-interfaces";
+
+/**
+ * SKU configuration for Log Analytics Workspace
+ */
+export interface LogAnalyticsWorkspaceSku {
+  /**
+   * SKU name for the Log Analytics Workspace
+   *
+   * Available options:
+   * - "Free" - Free tier (limited to 500MB/day, 7 day retention)
+   * - "Standard" - Standard tier (legacy)
+   * - "Premium" - Premium tier (legacy)
+   * - "PerNode" - Per node pricing (legacy, for OMS customers)
+   * - "PerGB2018" - Pay-as-you-go pricing based on data ingestion
+   * - "Standalone" - Standalone tier (legacy)
+   * - "CapacityReservation" - Commitment tier with reserved capacity
+   *
+   * @defaultValue "PerGB2018"
+   */
+  readonly name:
+    | "Free"
+    | "Standard"
+    | "Premium"
+    | "PerNode"
+    | "PerGB2018"
+    | "Standalone"
+    | "CapacityReservation";
+
+  /**
+   * Capacity reservation level in GB per day
+   * Only applicable when SKU name is "CapacityReservation"
+   * Valid values: 100, 200, 300, 400, 500, 1000, 2000, 5000
+   */
+  readonly capacityReservationLevel?: number;
+}
+
+/**
+ * Workspace capping configuration for daily data ingestion limits
+ */
+export interface LogAnalyticsWorkspaceCapping {
+  /**
+   * Daily volume cap in GB
+   * A value of -1 means no cap
+   */
+  readonly dailyQuotaGb: number;
+}
+
+/**
+ * Workspace features configuration
+ */
+export interface LogAnalyticsWorkspaceFeatures {
+  /**
+   * Flag indicating whether data export is enabled
+   */
+  readonly enableDataExport?: boolean;
+
+  /**
+   * Flag indicating whether data should be immediately purged after 30 days
+   * instead of the configured retention period
+   */
+  readonly immediatePurgeDataOn30Days?: boolean;
+
+  /**
+   * Flag indicating whether log access using AADIAM is disabled
+   */
+  readonly disableLocalAuth?: boolean;
+
+  /**
+   * Flag indicating whether cluster resource permissions are enabled
+   */
+  readonly enableLogAccessUsingOnlyResourcePermissions?: boolean;
+}
+
+/**
+ * Managed identity configuration for the workspace
+ */
+export interface LogAnalyticsWorkspaceIdentity {
+  /**
+   * Type of managed identity
+   */
+  readonly type:
+    | "SystemAssigned"
+    | "UserAssigned"
+    | "SystemAssigned,UserAssigned"
+    | "None";
+
+  /**
+   * User-assigned identity resource IDs
+   * Required when type includes UserAssigned
+   */
+  readonly userAssignedIdentities?: { [key: string]: any };
+}
+
+/**
+ * Properties for the unified Azure Log Analytics Workspace
+ *
+ * Extends AzapiResourceProps with Log Analytics Workspace specific properties
+ */
+export interface LogAnalyticsWorkspaceProps extends AzapiResourceProps {
+  /**
+   * Resource Group ID where the workspace will be created
+   * The workspace will be created as a child of this resource group
+   */
+  readonly resourceGroupId: string;
+
+  /**
+   * Data retention period in days
+   *
+   * Values between 30 and 730 are supported for pay-as-you-go pricing.
+   * Free tier is limited to 7 days.
+   *
+   * @defaultValue 30
+   */
+  readonly retentionInDays?: number;
+
+  /**
+   * SKU configuration for the workspace
+   *
+   * Determines pricing tier and capabilities of the workspace.
+   *
+   * @defaultValue { name: "PerGB2018" }
+   */
+  readonly sku?: LogAnalyticsWorkspaceSku;
+
+  /**
+   * Daily volume cap for data ingestion
+   *
+   * When the daily cap is reached, data ingestion stops until the next day.
+   * A value of dailyQuotaGb: -1 means no cap.
+   */
+  readonly workspaceCapping?: LogAnalyticsWorkspaceCapping;
+
+  /**
+   * Public network access for data ingestion
+   *
+   * Controls whether data can be ingested over the public internet.
+   *
+   * @defaultValue "Enabled"
+   */
+  readonly publicNetworkAccessForIngestion?: "Enabled" | "Disabled";
+
+  /**
+   * Public network access for querying data
+   *
+   * Controls whether queries can be executed over the public internet.
+   *
+   * @defaultValue "Enabled"
+   */
+  readonly publicNetworkAccessForQuery?: "Enabled" | "Disabled";
+
+  /**
+   * Workspace features configuration
+   *
+   * Enables or disables specific workspace features like data export,
+   * immediate purge, and local authentication.
+   */
+  readonly features?: LogAnalyticsWorkspaceFeatures;
+
+  /**
+   * Whether customer-managed keys are required for saved searches and alerts
+   *
+   * When enabled, all saved searches and alerts must use customer-managed keys.
+   */
+  readonly forceCmkForQuery?: boolean;
+
+  /**
+   * Resource ID of the default Data Collection Rule
+   *
+   * Associates a default DCR with the workspace for data collection.
+   * Only available in API version 2023-09-01 and later.
+   */
+  readonly defaultDataCollectionRuleResourceId?: string;
+
+  /**
+   * Managed identity configuration for the workspace
+   *
+   * Enables managed identity authentication for the workspace.
+   */
+  readonly identity?: LogAnalyticsWorkspaceIdentity;
+}
+
+/**
+ * Properties for the Log Analytics Workspace request body
+ */
+export interface LogAnalyticsWorkspaceBodyProperties {
+  readonly retentionInDays?: number;
+  readonly sku?: LogAnalyticsWorkspaceSku;
+  readonly workspaceCapping?: LogAnalyticsWorkspaceCapping;
+  readonly publicNetworkAccessForIngestion?: string;
+  readonly publicNetworkAccessForQuery?: string;
+  readonly features?: LogAnalyticsWorkspaceFeatures;
+  readonly forceCmkForQuery?: boolean;
+  readonly defaultDataCollectionRuleResourceId?: string;
+}
+
+/**
+ * The resource body interface for Azure Log Analytics Workspace API calls
+ */
+export interface LogAnalyticsWorkspaceBody {
+  readonly properties: LogAnalyticsWorkspaceBodyProperties;
+  readonly identity?: LogAnalyticsWorkspaceIdentity;
+}
+
+/**
+ * Unified Azure Log Analytics Workspace implementation
+ *
+ * This class provides a single, version-aware implementation that automatically handles version
+ * resolution, schema validation, and property transformation while maintaining full JSII compliance.
+ *
+ * Log Analytics Workspace is the central destination for log data from Azure resources,
+ * applications, and on-premises infrastructure. It enables querying, analysis, and
+ * visualization of log data using Kusto Query Language (KQL).
+ *
+ * @example
+ * // Basic Log Analytics Workspace with default settings:
+ * const workspace = new LogAnalyticsWorkspace(this, "my-workspace", {
+ *   name: "my-log-analytics",
+ *   location: "eastus",
+ *   resourceGroupId: resourceGroup.id,
+ * });
+ *
+ * @example
+ * // Log Analytics Workspace with custom retention and SKU:
+ * const workspace = new LogAnalyticsWorkspace(this, "production-workspace", {
+ *   name: "production-logs",
+ *   location: "eastus",
+ *   resourceGroupId: resourceGroup.id,
+ *   retentionInDays: 90,
+ *   sku: {
+ *     name: "PerGB2018"
+ *   },
+ *   publicNetworkAccessForIngestion: "Enabled",
+ *   publicNetworkAccessForQuery: "Enabled",
+ *   tags: {
+ *     environment: "production"
+ *   }
+ * });
+ *
+ * @example
+ * // Log Analytics Workspace with capacity reservation:
+ * const workspace = new LogAnalyticsWorkspace(this, "high-volume-workspace", {
+ *   name: "high-volume-logs",
+ *   location: "eastus",
+ *   resourceGroupId: resourceGroup.id,
+ *   retentionInDays: 365,
+ *   sku: {
+ *     name: "CapacityReservation",
+ *     capacityReservationLevel: 500
+ *   },
+ *   workspaceCapping: {
+ *     dailyQuotaGb: 100
+ *   }
+ * });
+ *
+ * @stability stable
+ */
+export class LogAnalyticsWorkspace extends AzapiResource {
+  static {
+    AzapiResource.registerSchemas(
+      LOG_ANALYTICS_WORKSPACE_TYPE,
+      ALL_LOG_ANALYTICS_WORKSPACE_VERSIONS,
+    );
+  }
+
+  /**
+   * The input properties for this Log Analytics Workspace instance
+   */
+  public readonly props: LogAnalyticsWorkspaceProps;
+
+  // Output properties for easy access and referencing
+  public readonly idOutput: cdktf.TerraformOutput;
+  public readonly nameOutput: cdktf.TerraformOutput;
+  public readonly workspaceIdOutput: cdktf.TerraformOutput;
+  public readonly customerIdOutput: cdktf.TerraformOutput;
+
+  /**
+   * Creates a new Azure Log Analytics Workspace using the AzapiResource framework
+   *
+   * The constructor automatically handles version resolution, schema registration,
+   * validation, and resource creation.
+   *
+   * @param scope - The scope in which to define this construct
+   * @param id - The unique identifier for this instance
+   * @param props - Configuration properties for the Log Analytics Workspace
+   */
+  constructor(scope: Construct, id: string, props: LogAnalyticsWorkspaceProps) {
+    // Validate retention days if provided
+    if (props.retentionInDays !== undefined) {
+      if (props.retentionInDays < 30 || props.retentionInDays > 730) {
+        throw new Error("retentionInDays must be between 30 and 730 days");
+      }
+    }
+
+    // Validate capacity reservation level if CapacityReservation SKU is used
+    if (props.sku?.name === "CapacityReservation") {
+      const validLevels = [100, 200, 300, 400, 500, 1000, 2000, 5000];
+      if (
+        props.sku.capacityReservationLevel === undefined ||
+        !validLevels.includes(props.sku.capacityReservationLevel)
+      ) {
+        throw new Error(
+          `capacityReservationLevel must be one of ${validLevels.join(", ")} when using CapacityReservation SKU`,
+        );
+      }
+    }
+
+    super(scope, id, props);
+
+    this.props = props;
+
+    // Create Terraform outputs for easy access and referencing from other resources
+    this.idOutput = new cdktf.TerraformOutput(this, "id", {
+      value: this.id,
+      description: "The ID of the Log Analytics Workspace",
+    });
+
+    this.nameOutput = new cdktf.TerraformOutput(this, "name", {
+      value: `\${${this.terraformResource.fqn}.name}`,
+      description: "The name of the Log Analytics Workspace",
+    });
+
+    this.workspaceIdOutput = new cdktf.TerraformOutput(this, "workspace_id", {
+      value: `\${${this.terraformResource.fqn}.output.properties.customerId}`,
+      description:
+        "The unique identifier (workspace ID) of the Log Analytics Workspace",
+    });
+
+    this.customerIdOutput = new cdktf.TerraformOutput(this, "customer_id", {
+      value: `\${${this.terraformResource.fqn}.output.properties.customerId}`,
+      description:
+        "The customer ID (same as workspace ID) of the Log Analytics Workspace",
+    });
+
+    // Override logical IDs
+    this.idOutput.overrideLogicalId("id");
+    this.nameOutput.overrideLogicalId("name");
+    this.workspaceIdOutput.overrideLogicalId("workspace_id");
+    this.customerIdOutput.overrideLogicalId("customer_id");
+  }
+
+  // =============================================================================
+  // REQUIRED ABSTRACT METHODS FROM AzapiResource
+  // =============================================================================
+
+  /**
+   * Gets the default API version to use when no explicit version is specified
+   * Returns the latest stable version as the default
+   */
+  protected defaultVersion(): string {
+    return "2023-09-01";
+  }
+
+  /**
+   * Gets the Azure resource type for Log Analytics Workspace
+   */
+  protected resourceType(): string {
+    return LOG_ANALYTICS_WORKSPACE_TYPE;
+  }
+
+  /**
+   * Gets the API schema for the resolved version
+   * Uses the framework's schema resolution to get the appropriate schema
+   */
+  protected apiSchema(): ApiSchema {
+    return this.resolveSchema();
+  }
+
+  /**
+   * Indicates that this resource type requires a location
+   */
+  protected requiresLocation(): boolean {
+    return true;
+  }
+
+  /**
+   * Creates the resource body for the Azure API call
+   * Transforms the input properties into the JSON format expected by Azure REST API
+   */
+  protected createResourceBody(props: any): any {
+    const typedProps = props as LogAnalyticsWorkspaceProps;
+
+    const body: any = {
+      properties: {
+        retentionInDays: typedProps.retentionInDays ?? 30,
+        sku: typedProps.sku ?? { name: "PerGB2018" },
+        publicNetworkAccessForIngestion:
+          typedProps.publicNetworkAccessForIngestion ?? "Enabled",
+        publicNetworkAccessForQuery:
+          typedProps.publicNetworkAccessForQuery ?? "Enabled",
+      },
+    };
+
+    // Add optional properties only if specified
+    if (typedProps.workspaceCapping) {
+      body.properties.workspaceCapping = typedProps.workspaceCapping;
+    }
+
+    if (typedProps.features) {
+      body.properties.features = typedProps.features;
+    }
+
+    if (typedProps.forceCmkForQuery !== undefined) {
+      body.properties.forceCmkForQuery = typedProps.forceCmkForQuery;
+    }
+
+    if (typedProps.defaultDataCollectionRuleResourceId) {
+      body.properties.defaultDataCollectionRuleResourceId =
+        typedProps.defaultDataCollectionRuleResourceId;
+    }
+
+    // Add identity at the top level if specified
+    if (typedProps.identity) {
+      body.identity = typedProps.identity;
+    }
+
+    return body;
+  }
+
+  /**
+   * Resolves the parent resource ID for Log Analytics Workspace
+   * Log Analytics Workspace is a top-level resource within a resource group
+   *
+   * @param props - The resource properties
+   * @returns The parent resource ID (the resource group)
+   */
+  protected resolveParentId(props: any): string {
+    return (props as LogAnalyticsWorkspaceProps).resourceGroupId;
+  }
+}

--- a/src/azure-loganalyticsworkspace/test/log-analytics-workspace.integ.ts
+++ b/src/azure-loganalyticsworkspace/test/log-analytics-workspace.integ.ts
@@ -1,0 +1,80 @@
+/**
+ * Integration test for Azure Log Analytics Workspace
+ *
+ * This test demonstrates basic usage of the LogAnalyticsWorkspace construct
+ * and validates deployment, idempotency, and cleanup.
+ *
+ * Run with: npm run integration:nostream
+ */
+
+import { Testing, TerraformStack } from "cdktf";
+import { Construct } from "constructs";
+import "cdktf/lib/testing/adapters/jest";
+import { ResourceGroup } from "../../azure-resourcegroup";
+import { AzapiProvider } from "../../core-azure/lib/azapi/providers-azapi/provider";
+import { TerraformApplyCheckAndDestroy } from "../../testing";
+import { LogAnalyticsWorkspace } from "../lib/log-analytics-workspace";
+
+/**
+ * Example stack demonstrating Log Analytics Workspace usage
+ */
+class LogAnalyticsWorkspaceExampleStack extends TerraformStack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    // Configure AZAPI provider
+    new AzapiProvider(this, "azapi", {});
+
+    // Create a resource group
+    const resourceGroup = new ResourceGroup(this, "example-rg", {
+      name: "law-example-rg",
+      location: "eastus",
+      tags: {
+        environment: "example",
+        purpose: "integration-test",
+      },
+    });
+
+    // Example 1: Basic Log Analytics Workspace
+    new LogAnalyticsWorkspace(this, "basic-workspace", {
+      name: "law-basic-example",
+      location: resourceGroup.props.location!,
+      resourceGroupId: resourceGroup.id,
+      tags: {
+        example: "basic",
+      },
+    });
+
+    // Example 2: Log Analytics Workspace with specific version
+    new LogAnalyticsWorkspace(this, "versioned-workspace", {
+      name: "law-versioned-example",
+      location: resourceGroup.props.location!,
+      resourceGroupId: resourceGroup.id,
+      retentionInDays: 60,
+      sku: {
+        name: "PerGB2018",
+      },
+      apiVersion: "2023-09-01",
+      tags: {
+        example: "versioned",
+      },
+    });
+  }
+}
+
+describe("Log Analytics Workspace Integration Test", () => {
+  it("should deploy, validate idempotency, and cleanup Log Analytics Workspace resources", () => {
+    const app = Testing.app();
+    const stack = new LogAnalyticsWorkspaceExampleStack(
+      app,
+      "test-log-analytics-workspace",
+    );
+    const synthesized = Testing.fullSynth(stack);
+
+    // This will:
+    // 1. Run terraform apply to deploy resources
+    // 2. Run terraform plan to check idempotency (no changes expected)
+    // 3. Run terraform destroy to cleanup resources
+    TerraformApplyCheckAndDestroy(synthesized);
+  }, 600000); // 10 minute timeout for deployment and cleanup
+});

--- a/src/azure-loganalyticsworkspace/test/log-analytics-workspace.spec.ts
+++ b/src/azure-loganalyticsworkspace/test/log-analytics-workspace.spec.ts
@@ -1,0 +1,653 @@
+/**
+ * Comprehensive tests for the LogAnalyticsWorkspace implementation
+ *
+ * This test suite validates the LogAnalyticsWorkspace class using the AzapiResource framework.
+ * Tests cover automatic version resolution, explicit version pinning, schema validation,
+ * property configurations, and resource creation.
+ */
+
+import { Testing } from "cdktf";
+import * as cdktf from "cdktf";
+import {
+  LogAnalyticsWorkspace,
+  LogAnalyticsWorkspaceProps,
+} from "../lib/log-analytics-workspace";
+
+describe("LogAnalyticsWorkspace - Implementation", () => {
+  let app: cdktf.App;
+  let stack: cdktf.TerraformStack;
+
+  beforeEach(() => {
+    app = Testing.app();
+    stack = new cdktf.TerraformStack(app, "TestStack");
+  });
+
+  // =============================================================================
+  // Constructor and Basic Properties
+  // =============================================================================
+
+  describe("Constructor and Basic Properties", () => {
+    it("should create a Log Analytics Workspace with minimal configuration", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "test-workspace",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      };
+
+      const workspace = new LogAnalyticsWorkspace(
+        stack,
+        "TestWorkspace",
+        props,
+      );
+
+      expect(workspace).toBeInstanceOf(LogAnalyticsWorkspace);
+      expect(workspace.props).toBe(props);
+      expect(workspace.props.name).toBe("test-workspace");
+      expect(workspace.props.location).toBe("eastus");
+    });
+
+    it("should create a Log Analytics Workspace with custom retention", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "retention-workspace",
+        location: "westus2",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        retentionInDays: 90,
+      };
+
+      const workspace = new LogAnalyticsWorkspace(
+        stack,
+        "RetentionWorkspace",
+        props,
+      );
+
+      expect(workspace.props.retentionInDays).toBe(90);
+    });
+
+    it("should create a Log Analytics Workspace with PerGB2018 SKU", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "sku-workspace",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        sku: {
+          name: "PerGB2018",
+        },
+      };
+
+      const workspace = new LogAnalyticsWorkspace(stack, "SkuWorkspace", props);
+
+      expect(workspace.props.sku?.name).toBe("PerGB2018");
+    });
+
+    it("should create a Log Analytics Workspace with CapacityReservation SKU", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "capacity-workspace",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        sku: {
+          name: "CapacityReservation",
+          capacityReservationLevel: 500,
+        },
+      };
+
+      const workspace = new LogAnalyticsWorkspace(
+        stack,
+        "CapacityWorkspace",
+        props,
+      );
+
+      expect(workspace.props.sku?.name).toBe("CapacityReservation");
+      expect(workspace.props.sku?.capacityReservationLevel).toBe(500);
+    });
+
+    it("should create a Log Analytics Workspace with workspace capping", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "capped-workspace",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        workspaceCapping: {
+          dailyQuotaGb: 100,
+        },
+      };
+
+      const workspace = new LogAnalyticsWorkspace(
+        stack,
+        "CappedWorkspace",
+        props,
+      );
+
+      expect(workspace.props.workspaceCapping?.dailyQuotaGb).toBe(100);
+    });
+  });
+
+  // =============================================================================
+  // Version Resolution
+  // =============================================================================
+
+  describe("Version Resolution", () => {
+    it("should use latest version 2023-09-01 when no version specified", () => {
+      const workspace = new LogAnalyticsWorkspace(stack, "DefaultVersion", {
+        name: "default-version-workspace",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      });
+
+      expect(workspace.resolvedApiVersion).toBe("2023-09-01");
+    });
+
+    it("should use explicit version when specified", () => {
+      const workspace = new LogAnalyticsWorkspace(stack, "PinnedVersion", {
+        name: "pinned-version-workspace",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        apiVersion: "2022-10-01",
+      });
+
+      expect(workspace.resolvedApiVersion).toBe("2022-10-01");
+    });
+
+    it("should use latest version 2023-09-01 when explicitly specified", () => {
+      const workspace = new LogAnalyticsWorkspace(stack, "LatestVersion", {
+        name: "latest-version-workspace",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        apiVersion: "2023-09-01",
+      });
+
+      expect(workspace.resolvedApiVersion).toBe("2023-09-01");
+    });
+  });
+
+  // =============================================================================
+  // Validation Tests
+  // =============================================================================
+
+  describe("Validation", () => {
+    it("should throw error when retention is below minimum", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "invalid-retention",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        retentionInDays: 7,
+      };
+
+      expect(() => {
+        new LogAnalyticsWorkspace(stack, "InvalidRetention", props);
+      }).toThrow(/retentionInDays must be between 30 and 730/);
+    });
+
+    it("should throw error when retention is above maximum", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "invalid-retention",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        retentionInDays: 1000,
+      };
+
+      expect(() => {
+        new LogAnalyticsWorkspace(stack, "InvalidRetentionMax", props);
+      }).toThrow(/retentionInDays must be between 30 and 730/);
+    });
+
+    it("should throw error when CapacityReservation SKU has invalid level", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "invalid-capacity",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        sku: {
+          name: "CapacityReservation",
+          capacityReservationLevel: 50, // Invalid level
+        },
+      };
+
+      expect(() => {
+        new LogAnalyticsWorkspace(stack, "InvalidCapacity", props);
+      }).toThrow(/capacityReservationLevel must be one of/);
+    });
+
+    it("should throw error when CapacityReservation SKU has no level", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "missing-capacity-level",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        sku: {
+          name: "CapacityReservation",
+        },
+      };
+
+      expect(() => {
+        new LogAnalyticsWorkspace(stack, "MissingCapacityLevel", props);
+      }).toThrow(/capacityReservationLevel must be one of/);
+    });
+
+    it("should accept valid retention values", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "valid-retention",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        retentionInDays: 365,
+      };
+
+      expect(() => {
+        new LogAnalyticsWorkspace(stack, "ValidRetention", props);
+      }).not.toThrow();
+    });
+
+    it("should accept valid CapacityReservation levels", () => {
+      const validLevels = [100, 200, 300, 400, 500, 1000, 2000, 5000];
+
+      validLevels.forEach((level, index) => {
+        const props: LogAnalyticsWorkspaceProps = {
+          name: `valid-capacity-${level}`,
+          location: "eastus",
+          resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+          sku: {
+            name: "CapacityReservation",
+            capacityReservationLevel: level,
+          },
+        };
+
+        expect(() => {
+          new LogAnalyticsWorkspace(stack, `ValidCapacity${index}`, props);
+        }).not.toThrow();
+      });
+    });
+  });
+
+  // =============================================================================
+  // Public Network Access Configuration
+  // =============================================================================
+
+  describe("Public Network Access Configuration", () => {
+    it("should configure public network access for ingestion", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "network-ingestion",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        publicNetworkAccessForIngestion: "Disabled",
+      };
+
+      const workspace = new LogAnalyticsWorkspace(
+        stack,
+        "NetworkIngestion",
+        props,
+      );
+
+      expect(workspace.props.publicNetworkAccessForIngestion).toBe("Disabled");
+    });
+
+    it("should configure public network access for query", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "network-query",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        publicNetworkAccessForQuery: "Disabled",
+      };
+
+      const workspace = new LogAnalyticsWorkspace(stack, "NetworkQuery", props);
+
+      expect(workspace.props.publicNetworkAccessForQuery).toBe("Disabled");
+    });
+
+    it("should configure both public network access settings", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "network-both",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        publicNetworkAccessForIngestion: "Disabled",
+        publicNetworkAccessForQuery: "Disabled",
+      };
+
+      const workspace = new LogAnalyticsWorkspace(stack, "NetworkBoth", props);
+
+      expect(workspace.props.publicNetworkAccessForIngestion).toBe("Disabled");
+      expect(workspace.props.publicNetworkAccessForQuery).toBe("Disabled");
+    });
+  });
+
+  // =============================================================================
+  // Workspace Features Configuration
+  // =============================================================================
+
+  describe("Workspace Features Configuration", () => {
+    it("should configure enableDataExport feature", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "feature-export",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        features: {
+          enableDataExport: true,
+        },
+      };
+
+      const workspace = new LogAnalyticsWorkspace(
+        stack,
+        "FeatureExport",
+        props,
+      );
+
+      expect(workspace.props.features?.enableDataExport).toBe(true);
+    });
+
+    it("should configure immediatePurgeDataOn30Days feature", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "feature-purge",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        features: {
+          immediatePurgeDataOn30Days: true,
+        },
+      };
+
+      const workspace = new LogAnalyticsWorkspace(stack, "FeaturePurge", props);
+
+      expect(workspace.props.features?.immediatePurgeDataOn30Days).toBe(true);
+    });
+
+    it("should configure disableLocalAuth feature", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "feature-auth",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        features: {
+          disableLocalAuth: true,
+        },
+      };
+
+      const workspace = new LogAnalyticsWorkspace(stack, "FeatureAuth", props);
+
+      expect(workspace.props.features?.disableLocalAuth).toBe(true);
+    });
+
+    it("should configure multiple features", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "feature-multi",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        features: {
+          enableDataExport: true,
+          immediatePurgeDataOn30Days: false,
+          disableLocalAuth: true,
+          enableLogAccessUsingOnlyResourcePermissions: true,
+        },
+      };
+
+      const workspace = new LogAnalyticsWorkspace(stack, "FeatureMulti", props);
+
+      expect(workspace.props.features?.enableDataExport).toBe(true);
+      expect(workspace.props.features?.immediatePurgeDataOn30Days).toBe(false);
+      expect(workspace.props.features?.disableLocalAuth).toBe(true);
+      expect(
+        workspace.props.features?.enableLogAccessUsingOnlyResourcePermissions,
+      ).toBe(true);
+    });
+  });
+
+  // =============================================================================
+  // Property Transformation
+  // =============================================================================
+
+  describe("Property Transformation", () => {
+    it("should generate correct Azure API format via createResourceBody", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "transform-test",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        retentionInDays: 60,
+        sku: {
+          name: "PerGB2018",
+        },
+      };
+
+      const workspace = new LogAnalyticsWorkspace(
+        stack,
+        "TransformTest",
+        props,
+      );
+
+      // Access the protected createResourceBody method
+      const resourceBody = (workspace as any).createResourceBody(props);
+
+      expect(resourceBody).toHaveProperty("properties");
+      expect(resourceBody.properties).toHaveProperty("retentionInDays", 60);
+      expect(resourceBody.properties).toHaveProperty("sku");
+      expect(resourceBody.properties.sku.name).toBe("PerGB2018");
+    });
+
+    it("should include workspaceCapping when specified", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "capping-test",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        workspaceCapping: {
+          dailyQuotaGb: 50,
+        },
+      };
+
+      const workspace = new LogAnalyticsWorkspace(stack, "CappingTest", props);
+      const resourceBody = (workspace as any).createResourceBody(props);
+
+      expect(resourceBody.properties.workspaceCapping).toBeDefined();
+      expect(resourceBody.properties.workspaceCapping.dailyQuotaGb).toBe(50);
+    });
+
+    it("should include identity when specified", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "identity-test",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        identity: {
+          type: "SystemAssigned",
+        },
+      };
+
+      const workspace = new LogAnalyticsWorkspace(stack, "IdentityTest", props);
+      const resourceBody = (workspace as any).createResourceBody(props);
+
+      expect(resourceBody.identity).toBeDefined();
+      expect(resourceBody.identity.type).toBe("SystemAssigned");
+    });
+
+    it("should apply default values for retention and SKU", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "defaults-test",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      };
+
+      const workspace = new LogAnalyticsWorkspace(stack, "DefaultsTest", props);
+      const resourceBody = (workspace as any).createResourceBody(props);
+
+      expect(resourceBody.properties.retentionInDays).toBe(30);
+      expect(resourceBody.properties.sku.name).toBe("PerGB2018");
+      expect(resourceBody.properties.publicNetworkAccessForIngestion).toBe(
+        "Enabled",
+      );
+      expect(resourceBody.properties.publicNetworkAccessForQuery).toBe(
+        "Enabled",
+      );
+    });
+  });
+
+  // =============================================================================
+  // Integration with Base Class
+  // =============================================================================
+
+  describe("Integration with Base Class", () => {
+    it("should inherit from AzapiResource", () => {
+      const workspace = new LogAnalyticsWorkspace(stack, "InheritanceTest", {
+        name: "inheritance-test",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      });
+
+      // Verify it has AzapiResource properties
+      expect(workspace).toHaveProperty("terraformResource");
+      expect(workspace).toHaveProperty("resolvedApiVersion");
+    });
+
+    it("should have correct resourceType", () => {
+      const workspace = new LogAnalyticsWorkspace(stack, "ResourceTypeTest", {
+        name: "resource-type-test",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      });
+
+      // Access the protected resourceType method
+      const resourceType = (workspace as any).resourceType();
+      expect(resourceType).toBe("Microsoft.OperationalInsights/workspaces");
+    });
+
+    it("should resolve parent ID correctly", () => {
+      const resourceGroupId = "/subscriptions/test-sub/resourceGroups/test-rg";
+
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "parent-id-test",
+        location: "eastus",
+        resourceGroupId,
+      };
+
+      const workspace = new LogAnalyticsWorkspace(stack, "ParentIdTest", props);
+
+      // Access the protected resolveParentId method
+      const parentId = (workspace as any).resolveParentId(props);
+      expect(parentId).toBe(resourceGroupId);
+    });
+
+    it("should generate resource outputs", () => {
+      const workspace = new LogAnalyticsWorkspace(stack, "OutputsTest", {
+        name: "outputs-test",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      });
+
+      expect(workspace.idOutput).toBeInstanceOf(cdktf.TerraformOutput);
+      expect(workspace.nameOutput).toBeInstanceOf(cdktf.TerraformOutput);
+      expect(workspace.workspaceIdOutput).toBeInstanceOf(cdktf.TerraformOutput);
+      expect(workspace.customerIdOutput).toBeInstanceOf(cdktf.TerraformOutput);
+      expect(workspace.id).toMatch(/^\$\{.*\.id\}$/);
+    });
+  });
+
+  // =============================================================================
+  // CDK Terraform Integration
+  // =============================================================================
+
+  describe("CDK Terraform Integration", () => {
+    it("should synthesize to valid Terraform configuration", () => {
+      new LogAnalyticsWorkspace(stack, "SynthTest", {
+        name: "synth-test",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        retentionInDays: 90,
+        sku: {
+          name: "PerGB2018",
+        },
+      });
+
+      const synthesized = Testing.synth(stack);
+      expect(synthesized).toBeDefined();
+
+      const stackConfig = JSON.parse(synthesized);
+      expect(stackConfig.resource).toBeDefined();
+    });
+
+    it("should handle multiple workspaces in the same stack", () => {
+      const workspace1 = new LogAnalyticsWorkspace(stack, "Workspace1", {
+        name: "workspace-1",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      });
+
+      const workspace2 = new LogAnalyticsWorkspace(stack, "Workspace2", {
+        name: "workspace-2",
+        location: "westus2",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        apiVersion: "2022-10-01",
+      });
+
+      expect(workspace1.resolvedApiVersion).toBe("2023-09-01");
+      expect(workspace2.resolvedApiVersion).toBe("2022-10-01");
+
+      const synthesized = Testing.synth(stack);
+      expect(synthesized).toBeDefined();
+    });
+  });
+
+  // =============================================================================
+  // Complex Scenarios
+  // =============================================================================
+
+  describe("Complex Scenarios", () => {
+    it("should handle comprehensive workspace configuration", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "comprehensive-workspace",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        retentionInDays: 365,
+        sku: {
+          name: "CapacityReservation",
+          capacityReservationLevel: 1000,
+        },
+        workspaceCapping: {
+          dailyQuotaGb: 200,
+        },
+        publicNetworkAccessForIngestion: "Enabled",
+        publicNetworkAccessForQuery: "Disabled",
+        features: {
+          enableDataExport: true,
+          immediatePurgeDataOn30Days: false,
+          disableLocalAuth: true,
+        },
+        forceCmkForQuery: true,
+        identity: {
+          type: "SystemAssigned",
+        },
+        tags: {
+          environment: "production",
+          team: "platform",
+        },
+      };
+
+      const workspace = new LogAnalyticsWorkspace(
+        stack,
+        "ComprehensiveConfig",
+        props,
+      );
+      const resourceBody = (workspace as any).createResourceBody(props);
+
+      expect(resourceBody.properties.retentionInDays).toBe(365);
+      expect(resourceBody.properties.sku.name).toBe("CapacityReservation");
+      expect(resourceBody.properties.sku.capacityReservationLevel).toBe(1000);
+      expect(resourceBody.properties.workspaceCapping.dailyQuotaGb).toBe(200);
+      expect(resourceBody.properties.publicNetworkAccessForIngestion).toBe(
+        "Enabled",
+      );
+      expect(resourceBody.properties.publicNetworkAccessForQuery).toBe(
+        "Disabled",
+      );
+      expect(resourceBody.properties.features.enableDataExport).toBe(true);
+      expect(resourceBody.properties.features.disableLocalAuth).toBe(true);
+      expect(resourceBody.properties.forceCmkForQuery).toBe(true);
+      expect(resourceBody.identity.type).toBe("SystemAssigned");
+    });
+
+    it("should handle workspace with defaultDataCollectionRuleResourceId", () => {
+      const dcrId =
+        "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/dataCollectionRules/test-dcr";
+
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "dcr-workspace",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        defaultDataCollectionRuleResourceId: dcrId,
+      };
+
+      const workspace = new LogAnalyticsWorkspace(stack, "DcrWorkspace", props);
+      const resourceBody = (workspace as any).createResourceBody(props);
+
+      expect(resourceBody.properties.defaultDataCollectionRuleResourceId).toBe(
+        dcrId,
+      );
+    });
+  });
+});

--- a/src/azure-networkwatcher/README.md
+++ b/src/azure-networkwatcher/README.md
@@ -1,0 +1,270 @@
+# Azure Network Watcher Construct
+
+This module provides a high-level TypeScript construct for managing Azure Network Watchers using the Terraform CDK and Azure AZAPI provider.
+
+## Features
+
+- **Multiple API Version Support**: Supports 2024-01-01 (latest) and 2023-11-01 (for backward compatibility)
+- **Automatic Version Resolution**: Uses the latest API version by default
+- **Version Pinning**: Lock to a specific API version for stability
+- **Type-Safe**: Full TypeScript support with comprehensive interfaces
+- **JSII Compatible**: Can be used from TypeScript, Python, Java, and C#
+- **Terraform Outputs**: Automatic creation of outputs for id, name, location, and provisioningState
+- **Tag Management**: Built-in methods for managing resource tags
+
+## Important Note: One Per Region Limitation
+
+⚠️ **Azure only allows one Network Watcher per subscription per region.** 
+
+If you attempt to create a Network Watcher in a region where one already exists, the deployment will fail. This is an Azure platform limitation, not a construct limitation.
+
+Azure automatically creates Network Watchers in a resource group named `NetworkWatcherRG` when certain network features are used. Before creating a Network Watcher, check if one already exists in your target region.
+
+## Supported API Versions
+
+| Version | Status | Release Date | Notes |
+|---------|--------|--------------|-------|
+| 2024-01-01 | Active (Latest) | 2024-01-01 | Recommended for new deployments |
+| 2023-11-01 | Active | 2023-11-01 | Stable release for backward compatibility |
+
+## Installation
+
+This module is part of the `@microsoft/terraform-cdk-constructs` package.
+
+```bash
+npm install @microsoft/terraform-cdk-constructs
+```
+
+## Basic Usage
+
+### Simple Network Watcher
+
+```typescript
+import { App, TerraformStack } from "cdktf";
+import { AzapiProvider } from "@microsoft/terraform-cdk-constructs/core-azure";
+import { ResourceGroup } from "@microsoft/terraform-cdk-constructs/azure-resourcegroup";
+import { NetworkWatcher } from "@microsoft/terraform-cdk-constructs/azure-networkwatcher";
+
+const app = new App();
+const stack = new TerraformStack(app, "network-watcher-stack");
+
+// Configure the Azure provider
+new AzapiProvider(stack, "azapi", {});
+
+// Create a resource group
+const resourceGroup = new ResourceGroup(stack, "rg", {
+  name: "my-resource-group",
+  location: "eastus",
+});
+
+// Create a Network Watcher
+const networkWatcher = new NetworkWatcher(stack, "network-watcher", {
+  name: "my-network-watcher",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  tags: {
+    environment: "production",
+  },
+});
+
+app.synth();
+```
+
+### Using Azure's Default Naming Convention
+
+Azure typically uses a naming convention of `NetworkWatcher_<region>` for auto-provisioned Network Watchers:
+
+```typescript
+const networkWatcher = new NetworkWatcher(stack, "network-watcher", {
+  name: "NetworkWatcher_eastus",
+  location: "eastus",
+  resourceGroupId: networkWatcherRg.id,
+});
+```
+
+### Pinning to a Specific API Version
+
+```typescript
+const networkWatcher = new NetworkWatcher(stack, "network-watcher", {
+  name: "my-network-watcher",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  apiVersion: "2023-11-01", // Pin to specific version
+});
+```
+
+## Using Network Watcher with Flow Logs
+
+Network Watcher is primarily used as a dependency for other Network Watcher features. Here's an example of how you might use it with NSG Flow Logs (once the Flow Log construct is available):
+
+```typescript
+// Create the Network Watcher
+const networkWatcher = new NetworkWatcher(stack, "network-watcher", {
+  name: "NetworkWatcher_eastus",
+  location: "eastus",
+  resourceGroupId: networkWatcherRg.id,
+});
+
+// Use the Network Watcher ID with Flow Logs or other features
+// (Flow Log construct example - coming soon)
+// const flowLog = new NsgFlowLog(stack, "flow-log", {
+//   networkWatcherId: networkWatcher.id,
+//   networkSecurityGroupId: nsg.id,
+//   storageAccountId: storageAccount.id,
+// });
+```
+
+## Network Watcher Features
+
+Network Watcher serves as the anchor for various network monitoring and diagnostic features:
+
+| Feature | Description |
+|---------|-------------|
+| **NSG Flow Logs** | Capture information about IP traffic flowing through NSGs |
+| **Connection Monitor** | Monitor reachability, latency, and network topology changes |
+| **Packet Capture** | Capture packets to/from virtual machines |
+| **IP Flow Verify** | Check if a packet is allowed or denied to/from a VM |
+| **Next Hop** | Get the next hop from a VM |
+| **VPN Troubleshoot** | Diagnose Azure VPN Gateway and connections |
+| **Network Topology** | View network resources and their relationships |
+| **Security Group View** | View NSGs and rules applied to a VM |
+
+## API Reference
+
+### NetworkWatcherProps
+
+Configuration properties for the Network Watcher construct.
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `name` | `string` | No* | Name of the Network Watcher. If not provided, uses the construct ID. |
+| `location` | `string` | Yes | Azure region where the Network Watcher will be created. Only one per region per subscription. |
+| `resourceGroupId` | `string` | Yes | Resource group ID where the Network Watcher will be created. |
+| `tags` | `{ [key: string]: string }` | No | Resource tags. |
+| `apiVersion` | `string` | No | Pin to a specific API version. |
+
+### Public Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `string` | The Azure resource ID of the Network Watcher. |
+| `props` | `NetworkWatcherProps` | The original input properties. |
+| `resolvedApiVersion` | `string` | The API version being used. |
+
+### Outputs
+
+The construct automatically creates Terraform outputs:
+
+- `id`: The Network Watcher resource ID
+- `name`: The Network Watcher name
+- `location`: The Network Watcher location (region)
+- `provisioning_state`: The provisioning state of the Network Watcher
+
+### Methods
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| `addTag` | `key: string, value: string` | Add a tag to the Network Watcher. |
+| `addAccess` | `objectId: string, roleDefinitionName: string` | Add RBAC role assignment. |
+
+## Best Practices
+
+### 1. Use a Dedicated Resource Group
+
+Consider using a dedicated resource group for Network Watchers, similar to Azure's convention:
+
+```typescript
+const networkWatcherRg = new ResourceGroup(stack, "network-watcher-rg", {
+  name: "NetworkWatcherRG",
+  location: "eastus",
+});
+
+const networkWatcher = new NetworkWatcher(stack, "network-watcher", {
+  name: "NetworkWatcher_eastus",
+  location: "eastus",
+  resourceGroupId: networkWatcherRg.id,
+});
+```
+
+### 2. Check for Existing Network Watchers
+
+Before creating a Network Watcher, verify that one doesn't already exist in the target region:
+
+```bash
+az network watcher list --query "[?location=='eastus']"
+```
+
+### 3. Create Network Watchers for Each Required Region
+
+If you need Network Watcher features in multiple regions, create a Network Watcher for each:
+
+```typescript
+const regions = ["eastus", "westus2", "northeurope"];
+
+regions.forEach(region => {
+  new NetworkWatcher(stack, `network-watcher-${region}`, {
+    name: `NetworkWatcher_${region}`,
+    location: region,
+    resourceGroupId: networkWatcherRg.id,
+  });
+});
+```
+
+### 4. Use Consistent Naming and Tagging
+
+```typescript
+const networkWatcher = new NetworkWatcher(stack, "network-watcher", {
+  name: "NetworkWatcher_eastus",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  tags: {
+    environment: "production",
+    "managed-by": "terraform-cdk",
+    "created-by": "platform-team",
+  },
+});
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **"A network watcher already exists in the subscription for region"**
+   
+   A Network Watcher already exists in that region. Azure allows only one per region per subscription.
+   
+   Solution: Import the existing Network Watcher or use a different region.
+
+2. **"Resource group not found"**
+   
+   The specified resource group doesn't exist.
+   
+   Solution: Ensure the resource group is created before the Network Watcher, either using a `ResourceGroup` construct or by referencing an existing resource group.
+
+3. **"Location is required"**
+   
+   Network Watcher requires a location to be specified.
+   
+   Solution: Always provide the `location` property.
+
+## Related Constructs
+
+- [`ResourceGroup`](../azure-resourcegroup/README.md) - Azure Resource Groups
+- [`VirtualNetwork`](../azure-virtualnetwork/README.md) - Azure Virtual Networks
+- [`NetworkSecurityGroup`](../azure-networksecuritygroup/README.md) - Network Security Groups
+
+## Additional Resources
+
+- [Azure Network Watcher Documentation](https://learn.microsoft.com/en-us/azure/network-watcher/network-watcher-overview)
+- [Network Watcher REST API Reference](https://learn.microsoft.com/en-us/rest/api/network-watcher/)
+- [NSG Flow Logs Documentation](https://learn.microsoft.com/en-us/azure/network-watcher/nsg-flow-logs-overview)
+- [Connection Monitor Documentation](https://learn.microsoft.com/en-us/azure/network-watcher/connection-monitor-overview)
+- [Terraform CDK Documentation](https://developer.hashicorp.com/terraform/cdktf)
+
+## Contributing
+
+Contributions are welcome! Please see the [Contributing Guide](../../CONTRIBUTING.md) for details.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](../../LICENSE) file for details.

--- a/src/azure-networkwatcher/index.ts
+++ b/src/azure-networkwatcher/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Azure Network Watcher module
+ *
+ * This module provides constructs for creating and managing Azure Network Watchers.
+ *
+ * Network Watcher is a regional service that provides network monitoring and diagnostic
+ * tools in Azure. It enables you to monitor and diagnose conditions at a network scenario
+ * level in, to, and from Azure.
+ *
+ * IMPORTANT: Azure only allows one Network Watcher per subscription per region.
+ * If you need Network Watcher functionality in multiple regions, you must create
+ * a separate Network Watcher for each region.
+ */
+
+export * from "./lib";

--- a/src/azure-networkwatcher/lib/index.ts
+++ b/src/azure-networkwatcher/lib/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Azure Network Watcher construct exports
+ */
+
+export * from "./network-watcher-schemas";
+export * from "./network-watcher";

--- a/src/azure-networkwatcher/lib/network-watcher-schemas.ts
+++ b/src/azure-networkwatcher/lib/network-watcher-schemas.ts
@@ -1,0 +1,185 @@
+/**
+ * API schemas for Azure Network Watcher across all supported versions
+ *
+ * This file defines the complete API schemas for Microsoft.Network/networkWatchers
+ * across all supported API versions. The schemas are used by the AzapiResource
+ * framework for validation, transformation, and version management.
+ *
+ * IMPORTANT: Azure only allows one Network Watcher per subscription per region.
+ * Network Watcher is primarily used as a dependency for other Network Watcher features like:
+ * - Flow Logs
+ * - Connection Monitor
+ * - Packet Capture
+ * - Network Diagnostic Tools
+ */
+
+import {
+  ApiSchema,
+  PropertyDefinition,
+  PropertyType,
+  ValidationRuleType,
+  VersionConfig,
+  VersionSupportLevel,
+} from "../../core-azure/lib/version-manager/interfaces/version-interfaces";
+
+// =============================================================================
+// COMMON PROPERTY DEFINITIONS
+// =============================================================================
+
+/**
+ * Common property definitions shared across all Network Watcher versions
+ *
+ * Network Watcher is a relatively simple resource with minimal properties.
+ * It primarily serves as an anchor for Network Watcher features (Flow Logs,
+ * Connection Monitor, Packet Capture, etc.) in a specific region.
+ */
+const COMMON_NETWORK_WATCHER_PROPERTIES: {
+  [key: string]: PropertyDefinition;
+} = {
+  name: {
+    dataType: PropertyType.STRING,
+    required: true,
+    description: "Name of the Network Watcher",
+    validation: [
+      {
+        ruleType: ValidationRuleType.REQUIRED,
+        message: "Name is required",
+      },
+      {
+        ruleType: ValidationRuleType.PATTERN_MATCH,
+        value: "^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,78}[a-zA-Z0-9_]$",
+        message:
+          "Network Watcher name must be 1-80 characters, start with a letter or number, end with a letter, number, or underscore, and contain only letters, numbers, underscores, periods, and hyphens",
+      },
+    ],
+  },
+  location: {
+    dataType: PropertyType.STRING,
+    required: true,
+    description:
+      "Azure region where the Network Watcher will be created. Note: Only one Network Watcher per region per subscription is allowed.",
+  },
+};
+
+// =============================================================================
+// VERSION-SPECIFIC SCHEMAS
+// =============================================================================
+
+/**
+ * API Schema for Network Watcher version 2024-01-01
+ *
+ * This is the latest stable version for Network Watcher.
+ * Network Watcher is a relatively simple resource - it primarily serves as
+ * an anchor for Network Watcher features in a region.
+ */
+export const NETWORK_WATCHER_SCHEMA_2024_01_01: ApiSchema = {
+  resourceType: "Microsoft.Network/networkWatchers",
+  version: "2024-01-01",
+  properties: {
+    ...COMMON_NETWORK_WATCHER_PROPERTIES,
+  },
+  required: ["name", "location"],
+  optional: [],
+  deprecated: [],
+  transformationRules: {},
+  validationRules: [
+    {
+      property: "name",
+      rules: [
+        {
+          ruleType: ValidationRuleType.REQUIRED,
+          message: "Name is required for Network Watcher",
+        },
+      ],
+    },
+  ],
+};
+
+/**
+ * API Schema for Network Watcher version 2023-11-01
+ *
+ * This is a stable version for backward compatibility.
+ * Network Watcher API is very stable with minimal changes between versions.
+ */
+export const NETWORK_WATCHER_SCHEMA_2023_11_01: ApiSchema = {
+  resourceType: "Microsoft.Network/networkWatchers",
+  version: "2023-11-01",
+  properties: {
+    ...COMMON_NETWORK_WATCHER_PROPERTIES,
+  },
+  required: ["name", "location"],
+  optional: [],
+  deprecated: [],
+  transformationRules: {},
+  validationRules: [
+    {
+      property: "name",
+      rules: [
+        {
+          ruleType: ValidationRuleType.REQUIRED,
+          message: "Name is required for Network Watcher",
+        },
+      ],
+    },
+  ],
+};
+
+// =============================================================================
+// VERSION CONFIGURATIONS
+// =============================================================================
+
+/**
+ * Version configuration for Network Watcher 2024-01-01
+ */
+export const NETWORK_WATCHER_VERSION_2024_01_01: VersionConfig = {
+  version: "2024-01-01",
+  schema: NETWORK_WATCHER_SCHEMA_2024_01_01,
+  supportLevel: VersionSupportLevel.ACTIVE,
+  releaseDate: "2024-01-01",
+  deprecationDate: undefined,
+  sunsetDate: undefined,
+  breakingChanges: [],
+  migrationGuide: "/docs/network-watcher/migration-2024-01-01",
+  changeLog: [
+    {
+      changeType: "updated",
+      description: "Latest stable API version",
+      breaking: false,
+    },
+  ],
+};
+
+/**
+ * Version configuration for Network Watcher 2023-11-01
+ */
+export const NETWORK_WATCHER_VERSION_2023_11_01: VersionConfig = {
+  version: "2023-11-01",
+  schema: NETWORK_WATCHER_SCHEMA_2023_11_01,
+  supportLevel: VersionSupportLevel.ACTIVE,
+  releaseDate: "2023-11-01",
+  deprecationDate: undefined,
+  sunsetDate: undefined,
+  breakingChanges: [],
+  migrationGuide: "/docs/network-watcher/migration-2023-11-01",
+  changeLog: [
+    {
+      changeType: "updated",
+      description: "Stable API version for backward compatibility",
+      breaking: false,
+    },
+  ],
+};
+
+/**
+ * All supported Network Watcher versions for registration
+ * Ordered with latest stable version first
+ */
+export const ALL_NETWORK_WATCHER_VERSIONS: VersionConfig[] = [
+  NETWORK_WATCHER_VERSION_2024_01_01,
+  NETWORK_WATCHER_VERSION_2023_11_01,
+];
+
+/**
+ * Resource type constant
+ */
+export const NETWORK_WATCHER_TYPE = "Microsoft.Network/networkWatchers";

--- a/src/azure-networkwatcher/lib/network-watcher.ts
+++ b/src/azure-networkwatcher/lib/network-watcher.ts
@@ -1,0 +1,266 @@
+/**
+ * Unified Azure Network Watcher implementation using AzapiResource framework
+ *
+ * This class provides a version-aware implementation for Azure Network Watcher
+ * that automatically handles version management, schema validation, and property
+ * transformation across all supported API versions.
+ *
+ * IMPORTANT: Azure only allows one Network Watcher per subscription per region.
+ * If you attempt to create a Network Watcher in a region where one already exists,
+ * the deployment will fail.
+ *
+ * Supported API Versions:
+ * - 2024-01-01 (Active, Latest)
+ * - 2023-11-01 (Active, Backward Compatibility)
+ *
+ * Features:
+ * - Automatic latest version resolution when no version is specified
+ * - Explicit version pinning for stability requirements
+ * - Schema-driven validation and transformation
+ * - Full JSII compliance for multi-language support
+ *
+ * Network Watcher is primarily used as a dependency for other Network Watcher features:
+ * - Flow Logs
+ * - Connection Monitor
+ * - Packet Capture
+ * - Network Diagnostic Tools
+ */
+
+import * as cdktf from "cdktf";
+import { Construct } from "constructs";
+import {
+  ALL_NETWORK_WATCHER_VERSIONS,
+  NETWORK_WATCHER_TYPE,
+} from "./network-watcher-schemas";
+import {
+  AzapiResource,
+  AzapiResourceProps,
+} from "../../core-azure/lib/azapi/azapi-resource";
+import { ApiSchema } from "../../core-azure/lib/version-manager/interfaces/version-interfaces";
+
+/**
+ * Properties for the unified Azure Network Watcher
+ *
+ * Extends AzapiResourceProps with Network Watcher specific properties.
+ *
+ * IMPORTANT: Azure only allows one Network Watcher per subscription per region.
+ * Attempting to create multiple Network Watchers in the same region will fail.
+ */
+export interface NetworkWatcherProps extends AzapiResourceProps {
+  /**
+   * Resource Group ID where the Network Watcher will be created
+   *
+   * The Network Watcher will be created as a child of this resource group.
+   * It's recommended to use a dedicated resource group for Network Watchers,
+   * as Azure automatically creates one named "NetworkWatcherRG" when certain
+   * network features are used.
+   */
+  readonly resourceGroupId: string;
+}
+
+/**
+ * The resource body interface for Azure Network Watcher API calls
+ *
+ * Network Watcher is a simple resource with minimal properties.
+ * The properties block is typically empty.
+ */
+export interface NetworkWatcherBody {
+  readonly properties: { [key: string]: any };
+}
+
+/**
+ * Unified Azure Network Watcher implementation
+ *
+ * This class provides a single, version-aware implementation that automatically handles version
+ * resolution, schema validation, and property transformation while maintaining full JSII compliance.
+ *
+ * Network Watcher is a regional service that provides tools to monitor, diagnose, and gain
+ * insights into your network health and performance in Azure. It serves as the anchor for
+ * Network Watcher features like Flow Logs, Connection Monitor, and Packet Capture.
+ *
+ * IMPORTANT CONSTRAINT: Azure only allows one Network Watcher per subscription per region.
+ * If you need Network Watcher functionality in multiple regions, you must create a separate
+ * Network Watcher for each region.
+ *
+ * @example
+ * // Basic Network Watcher:
+ * const networkWatcher = new NetworkWatcher(this, "network-watcher", {
+ *   name: "nw-eastus",
+ *   location: "eastus",
+ *   resourceGroupId: resourceGroup.id,
+ * });
+ *
+ * @example
+ * // Network Watcher with specific API version:
+ * const networkWatcher = new NetworkWatcher(this, "network-watcher", {
+ *   name: "nw-westus2",
+ *   location: "westus2",
+ *   resourceGroupId: resourceGroup.id,
+ *   apiVersion: "2024-01-01",
+ *   tags: {
+ *     environment: "production",
+ *   },
+ * });
+ *
+ * @example
+ * // Network Watcher for use with Flow Logs:
+ * const networkWatcher = new NetworkWatcher(this, "network-watcher", {
+ *   name: "NetworkWatcher_eastus",
+ *   location: "eastus",
+ *   resourceGroupId: networkWatcherRg.id,
+ * });
+ *
+ * // Then use it with NSG Flow Logs
+ * const flowLog = new NsgFlowLog(this, "flow-log", {
+ *   networkWatcherId: networkWatcher.id,
+ *   // ... other properties
+ * });
+ *
+ * @stability stable
+ */
+export class NetworkWatcher extends AzapiResource {
+  static {
+    AzapiResource.registerSchemas(
+      NETWORK_WATCHER_TYPE,
+      ALL_NETWORK_WATCHER_VERSIONS,
+    );
+  }
+
+  /**
+   * The input properties for this Network Watcher instance
+   */
+  public readonly props: NetworkWatcherProps;
+
+  // Output properties for easy access and referencing
+  /**
+   * Terraform output for the Network Watcher resource ID
+   */
+  public readonly idOutput: cdktf.TerraformOutput;
+
+  /**
+   * Terraform output for the Network Watcher name
+   */
+  public readonly nameOutput: cdktf.TerraformOutput;
+
+  /**
+   * Terraform output for the Network Watcher location
+   */
+  public readonly locationOutput: cdktf.TerraformOutput;
+
+  /**
+   * Terraform output for the Network Watcher provisioning state
+   */
+  public readonly provisioningStateOutput: cdktf.TerraformOutput;
+
+  /**
+   * Creates a new Azure Network Watcher using the AzapiResource framework
+   *
+   * The constructor automatically handles version resolution, schema registration,
+   * validation, and resource creation.
+   *
+   * IMPORTANT: Azure only allows one Network Watcher per subscription per region.
+   * Attempting to create a Network Watcher in a region where one already exists
+   * will result in a deployment error.
+   *
+   * @param scope - The scope in which to define this construct
+   * @param id - The unique identifier for this instance
+   * @param props - Configuration properties for the Network Watcher
+   */
+  constructor(scope: Construct, id: string, props: NetworkWatcherProps) {
+    super(scope, id, props);
+
+    this.props = props;
+
+    // Create Terraform outputs for easy access and referencing from other resources
+    this.idOutput = new cdktf.TerraformOutput(this, "id", {
+      value: this.id,
+      description: "The ID of the Network Watcher",
+    });
+
+    this.nameOutput = new cdktf.TerraformOutput(this, "name", {
+      value: `\${${this.terraformResource.fqn}.name}`,
+      description: "The name of the Network Watcher",
+    });
+
+    this.locationOutput = new cdktf.TerraformOutput(this, "location", {
+      value: `\${${this.terraformResource.fqn}.output.location}`,
+      description: "The location of the Network Watcher",
+    });
+
+    this.provisioningStateOutput = new cdktf.TerraformOutput(
+      this,
+      "provisioning_state",
+      {
+        value: `\${${this.terraformResource.fqn}.output.properties.provisioningState}`,
+        description: "The provisioning state of the Network Watcher",
+      },
+    );
+
+    // Override logical IDs
+    this.idOutput.overrideLogicalId("id");
+    this.nameOutput.overrideLogicalId("name");
+    this.locationOutput.overrideLogicalId("location");
+    this.provisioningStateOutput.overrideLogicalId("provisioning_state");
+  }
+
+  // =============================================================================
+  // REQUIRED ABSTRACT METHODS FROM AzapiResource
+  // =============================================================================
+
+  /**
+   * Gets the default API version to use when no explicit version is specified
+   * Returns the latest stable version as the default
+   */
+  protected defaultVersion(): string {
+    return "2024-01-01";
+  }
+
+  /**
+   * Gets the Azure resource type for Network Watcher
+   */
+  protected resourceType(): string {
+    return NETWORK_WATCHER_TYPE;
+  }
+
+  /**
+   * Gets the API schema for the resolved version
+   * Uses the framework's schema resolution to get the appropriate schema
+   */
+  protected apiSchema(): ApiSchema {
+    return this.resolveSchema();
+  }
+
+  /**
+   * Indicates that this resource type requires a location
+   */
+  protected requiresLocation(): boolean {
+    return true;
+  }
+
+  /**
+   * Creates the resource body for the Azure API call
+   *
+   * Network Watcher is a simple resource with an empty properties block.
+   * All configuration is handled at the resource level (name, location, tags).
+   */
+  protected createResourceBody(_props: any): any {
+    // Network Watcher has an empty properties block
+    // The resource is configured primarily through name, location, and tags
+    const body: any = {
+      properties: {},
+    };
+
+    return body;
+  }
+
+  /**
+   * Resolves the parent resource ID for Network Watcher
+   * Network Watcher is a top-level resource within a resource group
+   *
+   * @param props - The resource properties
+   * @returns The parent resource ID (the resource group)
+   */
+  protected resolveParentId(props: any): string {
+    return (props as NetworkWatcherProps).resourceGroupId;
+  }
+}

--- a/src/azure-networkwatcher/test/network-watcher.integ.ts
+++ b/src/azure-networkwatcher/test/network-watcher.integ.ts
@@ -1,0 +1,90 @@
+/**
+ * Integration test for Azure Network Watcher
+ *
+ * This test demonstrates basic usage of the NetworkWatcher construct
+ * and validates deployment, idempotency, and cleanup.
+ *
+ * IMPORTANT: Azure only allows one Network Watcher per subscription per region.
+ * If a Network Watcher already exists in the test region, this test will fail.
+ *
+ * Run with: npm run integration:nostream
+ */
+
+import { Testing, TerraformStack } from "cdktf";
+import { Construct } from "constructs";
+import "cdktf/lib/testing/adapters/jest";
+import { ResourceGroup } from "../../azure-resourcegroup";
+import { AzapiProvider } from "../../core-azure/lib/azapi/providers-azapi/provider";
+import { TerraformApplyCheckAndDestroy } from "../../testing";
+import { NetworkWatcher } from "../lib/network-watcher";
+
+/**
+ * Example stack demonstrating Network Watcher usage
+ *
+ * Note: This example creates a dedicated resource group for the Network Watcher.
+ * In practice, Azure often uses a resource group named "NetworkWatcherRG" for
+ * automatically provisioned Network Watchers.
+ */
+class NetworkWatcherExampleStack extends TerraformStack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    // Configure AZAPI provider
+    new AzapiProvider(this, "azapi", {});
+
+    // Create a resource group for Network Watcher
+    // Note: Azure typically uses NetworkWatcherRG for auto-provisioned Network Watchers
+    // Using northeurope to avoid conflict with existing Network Watchers
+    const resourceGroup = new ResourceGroup(this, "example-rg", {
+      name: "nw-example-rg",
+      location: "northeurope",
+      tags: {
+        environment: "example",
+        purpose: "integration-test",
+      },
+    });
+
+    // Example 1: Basic Network Watcher
+    // Note: Only one Network Watcher per region per subscription is allowed
+    new NetworkWatcher(this, "basic-network-watcher", {
+      name: "nw-basic-example",
+      location: resourceGroup.props.location!,
+      resourceGroupId: resourceGroup.id,
+      tags: {
+        example: "basic",
+      },
+    });
+
+    // Example 2: Network Watcher with specific version
+    // Using a different construct ID but same region (this is for demonstration only -
+    // in practice, you should only have one Network Watcher per region)
+    // This example shows version pinning but would fail if deployed alongside Example 1
+    // since both use the same region.
+    // Uncomment for testing version pinning in a different region:
+    /*
+    new NetworkWatcher(this, "versioned-network-watcher", {
+      name: "nw-versioned-example",
+      location: "westus2",  // Different region
+      resourceGroupId: resourceGroup.id,
+      apiVersion: "2024-01-01",
+      tags: {
+        example: "versioned",
+      },
+    });
+    */
+  }
+}
+
+describe("Network Watcher Integration Test", () => {
+  it("should deploy, validate idempotency, and cleanup Network Watcher resources", () => {
+    const app = Testing.app();
+    const stack = new NetworkWatcherExampleStack(app, "test-network-watcher");
+    const synthesized = Testing.fullSynth(stack);
+
+    // This will:
+    // 1. Run terraform apply to deploy resources
+    // 2. Run terraform plan to check idempotency (no changes expected)
+    // 3. Run terraform destroy to cleanup resources
+    TerraformApplyCheckAndDestroy(synthesized);
+  }, 600000); // 10 minute timeout for deployment and cleanup
+});

--- a/src/azure-networkwatcher/test/network-watcher.spec.ts
+++ b/src/azure-networkwatcher/test/network-watcher.spec.ts
@@ -1,0 +1,396 @@
+/**
+ * Comprehensive tests for the NetworkWatcher implementation
+ *
+ * This test suite validates the NetworkWatcher class using the AzapiResource framework.
+ * Tests cover automatic version resolution, explicit version pinning, schema validation,
+ * property configurations, and resource creation.
+ */
+
+import { Testing } from "cdktf";
+import * as cdktf from "cdktf";
+import { NetworkWatcher, NetworkWatcherProps } from "../lib/network-watcher";
+
+describe("NetworkWatcher - Implementation", () => {
+  let app: cdktf.App;
+  let stack: cdktf.TerraformStack;
+
+  beforeEach(() => {
+    app = Testing.app();
+    stack = new cdktf.TerraformStack(app, "TestStack");
+  });
+
+  // =============================================================================
+  // Constructor and Basic Properties
+  // =============================================================================
+
+  describe("Constructor and Basic Properties", () => {
+    it("should create a Network Watcher with minimal configuration", () => {
+      const props: NetworkWatcherProps = {
+        name: "test-network-watcher",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      };
+
+      const networkWatcher = new NetworkWatcher(
+        stack,
+        "TestNetworkWatcher",
+        props,
+      );
+
+      expect(networkWatcher).toBeInstanceOf(NetworkWatcher);
+      expect(networkWatcher.props).toBe(props);
+      expect(networkWatcher.props.name).toBe("test-network-watcher");
+      expect(networkWatcher.props.location).toBe("eastus");
+    });
+
+    it("should create a Network Watcher with tags", () => {
+      const props: NetworkWatcherProps = {
+        name: "tagged-network-watcher",
+        location: "westus2",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        tags: {
+          environment: "production",
+          team: "networking",
+        },
+      };
+
+      const networkWatcher = new NetworkWatcher(
+        stack,
+        "TaggedNetworkWatcher",
+        props,
+      );
+
+      expect(networkWatcher.props.tags).toEqual({
+        environment: "production",
+        team: "networking",
+      });
+    });
+
+    it("should create a Network Watcher with conventional naming", () => {
+      const props: NetworkWatcherProps = {
+        name: "NetworkWatcher_eastus",
+        location: "eastus",
+        resourceGroupId:
+          "/subscriptions/test-sub/resourceGroups/NetworkWatcherRG",
+      };
+
+      const networkWatcher = new NetworkWatcher(
+        stack,
+        "ConventionalNetworkWatcher",
+        props,
+      );
+
+      expect(networkWatcher.props.name).toBe("NetworkWatcher_eastus");
+    });
+  });
+
+  // =============================================================================
+  // Version Resolution
+  // =============================================================================
+
+  describe("Version Resolution", () => {
+    it("should use latest version 2024-01-01 when no version specified", () => {
+      const networkWatcher = new NetworkWatcher(stack, "DefaultVersion", {
+        name: "default-version-nw",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      });
+
+      expect(networkWatcher.resolvedApiVersion).toBe("2024-01-01");
+    });
+
+    it("should use explicit version when specified", () => {
+      const networkWatcher = new NetworkWatcher(stack, "PinnedVersion", {
+        name: "pinned-version-nw",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        apiVersion: "2023-11-01",
+      });
+
+      expect(networkWatcher.resolvedApiVersion).toBe("2023-11-01");
+    });
+
+    it("should use latest version 2024-01-01 when explicitly specified", () => {
+      const networkWatcher = new NetworkWatcher(stack, "LatestVersion", {
+        name: "latest-version-nw",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        apiVersion: "2024-01-01",
+      });
+
+      expect(networkWatcher.resolvedApiVersion).toBe("2024-01-01");
+    });
+  });
+
+  // =============================================================================
+  // Property Transformation
+  // =============================================================================
+
+  describe("Property Transformation", () => {
+    it("should generate correct Azure API format via createResourceBody", () => {
+      const props: NetworkWatcherProps = {
+        name: "transform-test",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      };
+
+      const networkWatcher = new NetworkWatcher(stack, "TransformTest", props);
+
+      // Access the protected createResourceBody method
+      const resourceBody = (networkWatcher as any).createResourceBody(props);
+
+      expect(resourceBody).toHaveProperty("properties");
+      expect(resourceBody.properties).toEqual({});
+    });
+
+    it("should have empty properties block for Network Watcher", () => {
+      const props: NetworkWatcherProps = {
+        name: "empty-props-test",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        tags: {
+          test: "value",
+        },
+      };
+
+      const networkWatcher = new NetworkWatcher(stack, "EmptyPropsTest", props);
+      const resourceBody = (networkWatcher as any).createResourceBody(props);
+
+      // Network Watcher properties should be empty - tags are handled at resource level
+      expect(Object.keys(resourceBody.properties).length).toBe(0);
+    });
+  });
+
+  // =============================================================================
+  // Integration with Base Class
+  // =============================================================================
+
+  describe("Integration with Base Class", () => {
+    it("should inherit from AzapiResource", () => {
+      const networkWatcher = new NetworkWatcher(stack, "InheritanceTest", {
+        name: "inheritance-test",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      });
+
+      // Verify it has AzapiResource properties
+      expect(networkWatcher).toHaveProperty("terraformResource");
+      expect(networkWatcher).toHaveProperty("resolvedApiVersion");
+    });
+
+    it("should have correct resourceType", () => {
+      const networkWatcher = new NetworkWatcher(stack, "ResourceTypeTest", {
+        name: "resource-type-test",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      });
+
+      // Access the protected resourceType method
+      const resourceType = (networkWatcher as any).resourceType();
+      expect(resourceType).toBe("Microsoft.Network/networkWatchers");
+    });
+
+    it("should resolve parent ID correctly", () => {
+      const resourceGroupId = "/subscriptions/test-sub/resourceGroups/test-rg";
+
+      const props: NetworkWatcherProps = {
+        name: "parent-id-test",
+        location: "eastus",
+        resourceGroupId,
+      };
+
+      const networkWatcher = new NetworkWatcher(stack, "ParentIdTest", props);
+
+      // Access the protected resolveParentId method
+      const parentId = (networkWatcher as any).resolveParentId(props);
+      expect(parentId).toBe(resourceGroupId);
+    });
+
+    it("should generate resource outputs", () => {
+      const networkWatcher = new NetworkWatcher(stack, "OutputsTest", {
+        name: "outputs-test",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      });
+
+      expect(networkWatcher.idOutput).toBeInstanceOf(cdktf.TerraformOutput);
+      expect(networkWatcher.nameOutput).toBeInstanceOf(cdktf.TerraformOutput);
+      expect(networkWatcher.locationOutput).toBeInstanceOf(
+        cdktf.TerraformOutput,
+      );
+      expect(networkWatcher.provisioningStateOutput).toBeInstanceOf(
+        cdktf.TerraformOutput,
+      );
+      expect(networkWatcher.id).toMatch(/^\$\{.*\.id\}$/);
+    });
+  });
+
+  // =============================================================================
+  // CDK Terraform Integration
+  // =============================================================================
+
+  describe("CDK Terraform Integration", () => {
+    it("should synthesize to valid Terraform configuration", () => {
+      new NetworkWatcher(stack, "SynthTest", {
+        name: "synth-test",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      });
+
+      const synthesized = Testing.synth(stack);
+      expect(synthesized).toBeDefined();
+
+      const stackConfig = JSON.parse(synthesized);
+      expect(stackConfig.resource).toBeDefined();
+    });
+
+    it("should handle multiple Network Watchers in the same stack (different regions)", () => {
+      // Note: In practice, Azure only allows one Network Watcher per region per subscription
+      // but CDK can synthesize multiple in the same stack for different regions
+      const nw1 = new NetworkWatcher(stack, "NetworkWatcher1", {
+        name: "nw-eastus",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      });
+
+      const nw2 = new NetworkWatcher(stack, "NetworkWatcher2", {
+        name: "nw-westus2",
+        location: "westus2",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        apiVersion: "2023-11-01",
+      });
+
+      expect(nw1.resolvedApiVersion).toBe("2024-01-01");
+      expect(nw2.resolvedApiVersion).toBe("2023-11-01");
+      expect(nw1.props.location).toBe("eastus");
+      expect(nw2.props.location).toBe("westus2");
+
+      const synthesized = Testing.synth(stack);
+      expect(synthesized).toBeDefined();
+    });
+  });
+
+  // =============================================================================
+  // Location Requirement
+  // =============================================================================
+
+  describe("Location Requirement", () => {
+    it("should require location for Network Watcher", () => {
+      const networkWatcher = new NetworkWatcher(stack, "LocationTest", {
+        name: "location-test",
+        location: "centralus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      });
+
+      // Access the protected requiresLocation method
+      const requiresLocation = (networkWatcher as any).requiresLocation();
+      expect(requiresLocation).toBe(true);
+    });
+
+    it("should accept various Azure regions", () => {
+      const regions = [
+        "eastus",
+        "westus2",
+        "northeurope",
+        "southeastasia",
+        "brazilsouth",
+      ];
+
+      regions.forEach((region, index) => {
+        const props: NetworkWatcherProps = {
+          name: `nw-${region}`,
+          location: region,
+          resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        };
+
+        expect(() => {
+          new NetworkWatcher(stack, `RegionTest${index}`, props);
+        }).not.toThrow();
+      });
+    });
+  });
+
+  // =============================================================================
+  // Naming Conventions
+  // =============================================================================
+
+  describe("Naming Conventions", () => {
+    it("should accept Azure default Network Watcher naming convention", () => {
+      // Azure typically creates Network Watchers with names like "NetworkWatcher_<region>"
+      const props: NetworkWatcherProps = {
+        name: "NetworkWatcher_eastus",
+        location: "eastus",
+        resourceGroupId:
+          "/subscriptions/test-sub/resourceGroups/NetworkWatcherRG",
+      };
+
+      expect(() => {
+        new NetworkWatcher(stack, "AzureDefaultNaming", props);
+      }).not.toThrow();
+    });
+
+    it("should accept custom naming with hyphens", () => {
+      const props: NetworkWatcherProps = {
+        name: "my-custom-network-watcher",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      };
+
+      expect(() => {
+        new NetworkWatcher(stack, "CustomNaming", props);
+      }).not.toThrow();
+    });
+
+    it("should accept naming with periods", () => {
+      const props: NetworkWatcherProps = {
+        name: "nw.prod.eastus",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      };
+
+      expect(() => {
+        new NetworkWatcher(stack, "PeriodNaming", props);
+      }).not.toThrow();
+    });
+  });
+
+  // =============================================================================
+  // Complete Example Configuration
+  // =============================================================================
+
+  describe("Complete Example Configuration", () => {
+    it("should handle comprehensive Network Watcher configuration", () => {
+      const props: NetworkWatcherProps = {
+        name: "comprehensive-network-watcher",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        apiVersion: "2024-01-01",
+        tags: {
+          environment: "production",
+          team: "platform",
+          "cost-center": "networking",
+          "managed-by": "terraform-cdk",
+        },
+      };
+
+      const networkWatcher = new NetworkWatcher(
+        stack,
+        "ComprehensiveConfig",
+        props,
+      );
+
+      expect(networkWatcher.props.name).toBe("comprehensive-network-watcher");
+      expect(networkWatcher.props.location).toBe("eastus");
+      expect(networkWatcher.resolvedApiVersion).toBe("2024-01-01");
+      expect(networkWatcher.props.tags).toEqual({
+        environment: "production",
+        team: "platform",
+        "cost-center": "networking",
+        "managed-by": "terraform-cdk",
+      });
+
+      const resourceBody = (networkWatcher as any).createResourceBody(props);
+      expect(resourceBody.properties).toEqual({});
+    });
+  });
+});

--- a/src/azure-policysetdefinition/README.md
+++ b/src/azure-policysetdefinition/README.md
@@ -1,0 +1,440 @@
+# Azure Policy Set Definition (Initiative) Construct
+
+This module provides a high-level TypeScript construct for managing Azure Policy Set Definitions (also known as Initiatives) using the Terraform CDK and Azure AZAPI provider.
+
+## Features
+
+- **Multiple API Version Support**: Supports 2023-04-01 (latest) and 2021-06-01 (for backward compatibility)
+- **Automatic Version Resolution**: Uses the latest API version by default
+- **Version Pinning**: Lock to a specific API version for stability
+- **Type-Safe**: Full TypeScript support with comprehensive interfaces
+- **JSII Compatible**: Can be used from TypeScript, Python, Java, and C#
+- **Terraform Outputs**: Automatic creation of outputs for id, name, and policySetDefinitionId
+- **Policy Definition References**: Support for including multiple policy definitions
+- **Policy Definition Groups**: Organize policies within initiatives
+- **Initiative Parameters**: Define parameters that can be used across policies in the set
+- **Metadata Support**: Categorization with category, version, preview, and deprecated flags
+
+## What is a Policy Set Definition (Initiative)?
+
+A Policy Set Definition, also known as an "Initiative" in the Azure Portal, is a collection of policy definitions that are grouped together toward a specific goal. Initiatives simplify managing and assigning policies by grouping a set of policies as one single item.
+
+**Key Benefits:**
+- **Simplified Assignment**: Assign multiple policies at once
+- **Compliance Grouping**: Group related compliance controls together
+- **Parameter Inheritance**: Pass parameters to multiple policies from a single assignment
+- **Organized Management**: Use groups to categorize policies within an initiative
+
+## Supported API Versions
+
+| Version | Status | Release Date | Notes |
+|---------|--------|--------------|-------|
+| 2023-04-01 | Active (Latest) | 2023-04-01 | Recommended for new deployments |
+| 2021-06-01 | Active | 2021-06-01 | Stable release for backward compatibility |
+
+## Installation
+
+This module is part of the `@microsoft/terraform-cdk-constructs` package.
+
+```bash
+npm install @microsoft/terraform-cdk-constructs
+```
+
+## Basic Usage
+
+### Simple Initiative with Built-in Policies
+
+```typescript
+import { App, TerraformStack } from "cdktf";
+import { AzapiProvider } from "@microsoft/terraform-cdk-constructs/core-azure";
+import { PolicySetDefinition } from "@microsoft/terraform-cdk-constructs/azure-policysetdefinition";
+
+const app = new App();
+const stack = new TerraformStack(app, "policy-stack");
+
+// Configure the Azure provider
+new AzapiProvider(stack, "azapi", {});
+
+// Create a Policy Set Definition (Initiative)
+const initiative = new PolicySetDefinition(stack, "security-initiative", {
+  displayName: "Security Baseline Initiative",
+  description: "Applies security baseline policies to ensure compliance",
+  scope: "/subscriptions/00000000-0000-0000-0000-000000000000",
+  policyDefinitions: [
+    {
+      // Audit VMs that do not use managed disks
+      policyDefinitionId: "/providers/Microsoft.Authorization/policyDefinitions/06a78e20-9358-41c9-923c-fb736d382a4d",
+      policyDefinitionReferenceId: "auditManagedDisks",
+    },
+    {
+      // Audit location of resources
+      policyDefinitionId: "/providers/Microsoft.Authorization/policyDefinitions/e56962a6-4747-49cd-b67b-bf8b01975c4c",
+      policyDefinitionReferenceId: "allowedLocations",
+    },
+  ],
+  tags: {
+    environment: "production",
+    compliance: "required",
+  },
+});
+
+app.synth();
+```
+
+## Advanced Usage
+
+### Initiative with Parameters
+
+```typescript
+const initiative = new PolicySetDefinition(stack, "parameterized-initiative", {
+  displayName: "Tagging Governance Initiative",
+  description: "Ensures all resources have required tags",
+  scope: "/subscriptions/00000000-0000-0000-0000-000000000000",
+  parameters: {
+    requiredTagName: {
+      type: "String",
+      displayName: "Required Tag Name",
+      description: "Name of the tag that must be present on resources",
+      defaultValue: "costCenter",
+    },
+    requiredTagValue: {
+      type: "String",
+      displayName: "Required Tag Value",
+      description: "Expected value for the required tag",
+    },
+  },
+  policyDefinitions: [
+    {
+      policyDefinitionId: "/providers/Microsoft.Authorization/policyDefinitions/1e30110a-5ceb-460c-a204-c1c3969c6d62",
+      policyDefinitionReferenceId: "requireTagOnResourceGroup",
+      parameters: {
+        tagName: { value: "[parameters('requiredTagName')]" },
+      },
+    },
+    {
+      policyDefinitionId: "/providers/Microsoft.Authorization/policyDefinitions/726aca4c-86e9-4b04-b0c5-073027359532",
+      policyDefinitionReferenceId: "inheritTagFromResourceGroup",
+      parameters: {
+        tagName: { value: "[parameters('requiredTagName')]" },
+      },
+    },
+  ],
+});
+```
+
+### Initiative with Policy Groups
+
+```typescript
+const initiative = new PolicySetDefinition(stack, "grouped-initiative", {
+  displayName: "Comprehensive Compliance Initiative",
+  description: "Security and compliance policies organized by category",
+  scope: "/subscriptions/00000000-0000-0000-0000-000000000000",
+  metadata: {
+    category: "Regulatory Compliance",
+    version: "2.0.0",
+  },
+  policyDefinitionGroups: [
+    {
+      name: "NetworkSecurity",
+      displayName: "Network Security Policies",
+      category: "Network",
+      description: "Policies for network security controls",
+    },
+    {
+      name: "DataProtection",
+      displayName: "Data Protection Policies",
+      category: "Data",
+      description: "Policies for data protection and encryption",
+    },
+    {
+      name: "IdentityAndAccess",
+      displayName: "Identity & Access Policies",
+      category: "IAM",
+      description: "Policies for identity and access management",
+    },
+  ],
+  policyDefinitions: [
+    {
+      policyDefinitionId: "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+      policyDefinitionReferenceId: "networkSecurityPolicy1",
+      groupNames: ["NetworkSecurity"],
+    },
+    {
+      policyDefinitionId: "/providers/Microsoft.Authorization/policyDefinitions/policy-2",
+      policyDefinitionReferenceId: "dataProtectionPolicy1",
+      groupNames: ["DataProtection"],
+    },
+    {
+      policyDefinitionId: "/providers/Microsoft.Authorization/policyDefinitions/policy-3",
+      policyDefinitionReferenceId: "crossCuttingPolicy",
+      groupNames: ["NetworkSecurity", "DataProtection"],
+    },
+  ],
+});
+```
+
+### Combining Custom and Built-in Policies
+
+```typescript
+import { PolicyDefinition } from "@microsoft/terraform-cdk-constructs/azure-policydefinition";
+
+// Create a custom policy definition first
+const customPolicy = new PolicyDefinition(stack, "custom-audit-policy", {
+  displayName: "Audit Custom Tag",
+  scope: "/subscriptions/00000000-0000-0000-0000-000000000000",
+  policyRule: {
+    if: {
+      field: "tags['department']",
+      exists: "false",
+    },
+    then: {
+      effect: "audit",
+    },
+  },
+});
+
+// Create an initiative that combines the custom policy with built-in policies
+const initiative = new PolicySetDefinition(stack, "combined-initiative", {
+  displayName: "Combined Policies Initiative",
+  scope: "/subscriptions/00000000-0000-0000-0000-000000000000",
+  policyDefinitions: [
+    {
+      // Reference the custom policy
+      policyDefinitionId: customPolicy.id,
+      policyDefinitionReferenceId: "customAuditTag",
+    },
+    {
+      // Built-in policy
+      policyDefinitionId: "/providers/Microsoft.Authorization/policyDefinitions/06a78e20-9358-41c9-923c-fb736d382a4d",
+      policyDefinitionReferenceId: "builtInAuditVMs",
+    },
+  ],
+});
+```
+
+### Management Group Scope
+
+```typescript
+const mgInitiative = new PolicySetDefinition(stack, "mg-initiative", {
+  displayName: "Organization-wide Initiative",
+  description: "Applies to all subscriptions in the management group",
+  scope: "/providers/Microsoft.Management/managementGroups/my-management-group",
+  policyDefinitions: [
+    {
+      policyDefinitionId: "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+      policyDefinitionReferenceId: "orgPolicy1",
+    },
+  ],
+});
+```
+
+### Pinning to a Specific API Version
+
+```typescript
+const initiative = new PolicySetDefinition(stack, "pinned-initiative", {
+  displayName: "Stable Initiative",
+  scope: "/subscriptions/00000000-0000-0000-0000-000000000000",
+  apiVersion: "2021-06-01", // Pin to specific version
+  policyDefinitions: [
+    {
+      policyDefinitionId: "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+    },
+  ],
+});
+```
+
+### Using Outputs for Policy Assignment
+
+```typescript
+import { TerraformOutput } from "cdktf";
+
+const initiative = new PolicySetDefinition(stack, "initiative", {
+  displayName: "My Initiative",
+  scope: subscriptionId,
+  policyDefinitions: [
+    {
+      policyDefinitionId: "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+    },
+  ],
+});
+
+// Use the initiative ID in a policy assignment
+// The policySetDefinitionId property can be referenced from other resources
+console.log(initiative.policySetDefinitionId); // Terraform interpolation string
+
+// Create outputs for cross-stack references
+new TerraformOutput(stack, "initiative-id", {
+  value: initiative.idOutput,
+});
+```
+
+## API Reference
+
+### PolicySetDefinitionProps
+
+Configuration properties for the Policy Set Definition construct.
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `name` | `string` | No | Resource name. Auto-generated as UUID if not provided. |
+| `displayName` | `string` | Yes | Display name shown in Azure Portal. |
+| `description` | `string` | No | Description of the initiative. |
+| `scope` | `string` | Yes | Subscription or management group scope for the definition. |
+| `policyType` | `"BuiltIn" \| "Custom" \| "Static"` | No | Type of policy set. Default: "Custom". |
+| `metadata` | `PolicySetMetadata` | No | Metadata for categorization. |
+| `parameters` | `{ [key: string]: PolicySetParameterDefinition }` | No | Initiative parameter definitions. |
+| `policyDefinitions` | `PolicyDefinitionReference[]` | Yes | Array of policy definition references. |
+| `policyDefinitionGroups` | `PolicyDefinitionGroup[]` | No | Groups for organizing policies. |
+| `tags` | `{ [key: string]: string }` | No | Resource tags. |
+| `apiVersion` | `string` | No | Pin to a specific API version. |
+
+### PolicyDefinitionReference
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `policyDefinitionId` | `string` | Yes | ID of the policy definition to include. |
+| `policyDefinitionReferenceId` | `string` | No | Unique ID within the set. |
+| `parameters` | `{ [key: string]: PolicyParameterValue }` | No | Parameter values for this policy. |
+| `groupNames` | `string[]` | No | Groups this policy belongs to. |
+
+### PolicyDefinitionGroup
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `name` | `string` | Yes | Unique group name within the set. |
+| `displayName` | `string` | No | Display name in Azure Portal. |
+| `category` | `string` | No | Category for organization. |
+| `description` | `string` | No | Description of the group. |
+
+### PolicySetMetadata
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `category` | `string` | No | Category for Azure Portal organization. |
+| `version` | `string` | No | Version of the initiative. |
+| `preview` | `boolean` | No | Whether this is a preview initiative. |
+| `deprecated` | `boolean` | No | Whether this initiative is deprecated. |
+
+### PolicySetParameterDefinition
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `type` | `string` | Yes | Data type: String, Array, Object, Boolean, Integer, Float, DateTime. |
+| `displayName` | `string` | No | Display name in Azure Portal. |
+| `description` | `string` | No | Parameter description. |
+| `defaultValue` | `any` | No | Default value for the parameter. |
+| `allowedValues` | `any[]` | No | Allowed values for the parameter. |
+| `metadata` | `object` | No | Additional metadata (e.g., strongType). |
+
+### Public Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `string` | The Azure resource ID of the policy set definition. |
+| `policySetDefinitionId` | `string` | Alias for id, for use in policy assignments. |
+| `displayName` | `string` | The display name of the initiative. |
+| `policyType` | `string` | The policy type (Custom, BuiltIn, Static). |
+| `policyDefinitionCount` | `number` | Number of policy definitions in this set. |
+| `props` | `PolicySetDefinitionProps` | The original input properties. |
+| `resolvedApiVersion` | `string` | The API version being used. |
+
+### Outputs
+
+The construct automatically creates Terraform outputs:
+
+- `id`: The policy set definition resource ID
+- `name`: The policy set definition resource name
+- `policy_set_definition_id`: The ID for use in policy assignments
+
+## Best Practices
+
+### 1. Use Descriptive Reference IDs
+
+```typescript
+policyDefinitions: [
+  {
+    policyDefinitionId: "...",
+    policyDefinitionReferenceId: "auditStorageAccountEncryption", // Descriptive name
+  },
+]
+```
+
+### 2. Organize with Groups
+
+Use policy definition groups to categorize policies for better management and compliance reporting:
+
+```typescript
+policyDefinitionGroups: [
+  { name: "Security", category: "Security Center" },
+  { name: "Compliance", category: "Regulatory" },
+  { name: "CostManagement", category: "Cost" },
+],
+```
+
+### 3. Use Initiative Parameters
+
+Define parameters at the initiative level to allow flexibility during assignment:
+
+```typescript
+parameters: {
+  effect: {
+    type: "String",
+    defaultValue: "Audit",
+    allowedValues: ["Audit", "Deny", "Disabled"],
+  },
+},
+```
+
+### 4. Version Your Initiatives
+
+Use metadata to track initiative versions:
+
+```typescript
+metadata: {
+  category: "Security",
+  version: "1.0.0",
+},
+```
+
+### 5. Use Management Group Scope for Enterprise
+
+For organization-wide initiatives, create them at management group level:
+
+```typescript
+scope: "/providers/Microsoft.Management/managementGroups/root-mg",
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Empty policyDefinitions**: At least one policy definition reference is required.
+
+2. **Invalid Group Reference**: Ensure all groupNames in policy definitions exist in policyDefinitionGroups.
+
+3. **Duplicate Group Names**: Each group name must be unique within the policy set.
+
+4. **Missing policyDefinitionId**: Every policy definition reference requires a policyDefinitionId.
+
+5. **API Version Errors**: Ensure the version is 2023-04-01 or 2021-06-01.
+
+## Related Constructs
+
+- [`PolicyDefinition`](../azure-policydefinition/README.md) - Create custom policy definitions
+- [`PolicyAssignment`](../azure-policyassignment/README.md) - Assign policies and initiatives
+- [`ResourceGroup`](../azure-resourcegroup/README.md) - Azure Resource Groups
+
+## Additional Resources
+
+- [Azure Policy Documentation](https://learn.microsoft.com/en-us/azure/governance/policy/overview)
+- [Azure Policy Initiative Definition](https://learn.microsoft.com/en-us/azure/governance/policy/concepts/initiative-definition-structure)
+- [Azure REST API Reference](https://learn.microsoft.com/en-us/rest/api/policy/policy-set-definitions)
+- [Terraform CDK Documentation](https://developer.hashicorp.com/terraform/cdktf)
+
+## Contributing
+
+Contributions are welcome! Please see the [Contributing Guide](../../CONTRIBUTING.md) for details.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](../../LICENSE) file for details.

--- a/src/azure-policysetdefinition/index.ts
+++ b/src/azure-policysetdefinition/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Azure Policy Set Definition (Initiative) module
+ *
+ * This module provides constructs for creating and managing Azure Policy Set Definitions
+ * (also known as Initiatives in Azure Portal).
+ *
+ * Policy Set Definitions allow you to group multiple policy definitions together
+ * and assign them as a single unit for easier governance and compliance management.
+ */
+
+export * from "./lib";

--- a/src/azure-policysetdefinition/lib/index.ts
+++ b/src/azure-policysetdefinition/lib/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Azure Policy Set Definition (Initiative) construct exports
+ */
+
+export * from "./policy-set-definition-schemas";
+export * from "./policy-set-definition";

--- a/src/azure-policysetdefinition/lib/policy-set-definition-schemas.ts
+++ b/src/azure-policysetdefinition/lib/policy-set-definition-schemas.ts
@@ -1,0 +1,283 @@
+/**
+ * API schemas for Azure Policy Set Definition (Initiative) across all supported versions
+ *
+ * This file defines the complete API schemas for Microsoft.Authorization/policySetDefinitions
+ * across all supported API versions. The schemas are used by the AzapiResource
+ * framework for validation, transformation, and version management.
+ *
+ * Policy Set Definitions (also known as Initiatives) are collections of policy definitions
+ * that allow you to group policies and assign them together as a single unit.
+ */
+
+import {
+  ApiSchema,
+  PropertyDefinition,
+  PropertyType,
+  ValidationRuleType,
+  VersionConfig,
+  VersionSupportLevel,
+} from "../../core-azure/lib/version-manager/interfaces/version-interfaces";
+
+// =============================================================================
+// COMMON PROPERTY DEFINITIONS
+// =============================================================================
+
+/**
+ * Common property definitions shared across all Policy Set Definition versions
+ */
+const COMMON_PROPERTIES: { [key: string]: PropertyDefinition } = {
+  name: {
+    dataType: PropertyType.STRING,
+    required: false,
+    description:
+      "The name of the policy set definition resource. Automatically generated as a GUID if not provided.",
+    validation: [],
+  },
+  displayName: {
+    dataType: PropertyType.STRING,
+    required: true,
+    description:
+      "The display name of the policy set definition shown in the Azure portal",
+    validation: [
+      {
+        ruleType: ValidationRuleType.REQUIRED,
+        message: "Display name is required for policy set definitions",
+      },
+      {
+        ruleType: ValidationRuleType.VALUE_RANGE,
+        value: { minLength: 1, maxLength: 128 },
+        message: "Display name must be between 1 and 128 characters",
+      },
+    ],
+  },
+  description: {
+    dataType: PropertyType.STRING,
+    required: false,
+    description:
+      "The description of the policy set definition explaining its purpose and scope",
+    validation: [
+      {
+        ruleType: ValidationRuleType.VALUE_RANGE,
+        value: { minLength: 0, maxLength: 512 },
+        message: "Description must not exceed 512 characters",
+      },
+    ],
+  },
+  policyType: {
+    dataType: PropertyType.STRING,
+    required: false,
+    defaultValue: "Custom",
+    description:
+      "The type of policy set definition. Valid values: BuiltIn, Custom, Static",
+    validation: [
+      {
+        ruleType: ValidationRuleType.PATTERN_MATCH,
+        value: "^(BuiltIn|Custom|Static)$",
+        message: "Policy type must be BuiltIn, Custom, or Static",
+      },
+    ],
+  },
+  metadata: {
+    dataType: PropertyType.OBJECT,
+    required: false,
+    description:
+      "Metadata object for categorization including category, version, preview, and deprecated flags",
+  },
+  parameters: {
+    dataType: PropertyType.OBJECT,
+    required: false,
+    description:
+      "Parameter definitions that can be used by policy definitions in the set",
+  },
+  policyDefinitions: {
+    dataType: PropertyType.ARRAY,
+    required: true,
+    description:
+      "Array of policy definition references included in this policy set",
+    validation: [
+      {
+        ruleType: ValidationRuleType.REQUIRED,
+        message:
+          "Policy definitions array is required for policy set definitions",
+      },
+      {
+        ruleType: ValidationRuleType.TYPE_CHECK,
+        value: PropertyType.ARRAY,
+        message:
+          "Policy definitions must be an array of policy definition references",
+      },
+    ],
+  },
+  policyDefinitionGroups: {
+    dataType: PropertyType.ARRAY,
+    required: false,
+    description:
+      "Groups for organizing policy definitions within the policy set",
+  },
+};
+
+// =============================================================================
+// VERSION-SPECIFIC SCHEMAS
+// =============================================================================
+
+/**
+ * API Schema for Policy Set Definition version 2023-04-01
+ *
+ * This is the latest stable version for Policy Set Definitions.
+ * It includes support for:
+ * - Policy definition references with parameters
+ * - Policy definition groups for organization
+ * - Metadata for categorization
+ * - Parameter definitions for the initiative
+ */
+export const POLICY_SET_DEFINITION_SCHEMA_2023_04_01: ApiSchema = {
+  resourceType: "Microsoft.Authorization/policySetDefinitions",
+  version: "2023-04-01",
+  properties: {
+    ...COMMON_PROPERTIES,
+  },
+  required: ["displayName", "policyDefinitions"],
+  optional: [
+    "name",
+    "description",
+    "policyType",
+    "metadata",
+    "parameters",
+    "policyDefinitionGroups",
+  ],
+  deprecated: [],
+  transformationRules: {},
+  validationRules: [
+    {
+      property: "displayName",
+      rules: [
+        {
+          ruleType: ValidationRuleType.REQUIRED,
+          message: "Display name is required for policy set definitions",
+        },
+      ],
+    },
+    {
+      property: "policyDefinitions",
+      rules: [
+        {
+          ruleType: ValidationRuleType.REQUIRED,
+          message:
+            "Policy definitions array is required for policy set definitions",
+        },
+      ],
+    },
+  ],
+};
+
+/**
+ * API Schema for Policy Set Definition version 2021-06-01
+ *
+ * This is a stable version for backward compatibility.
+ * It includes support for:
+ * - Policy definition references with parameters
+ * - Policy definition groups for organization
+ * - Metadata for categorization
+ * - Parameter definitions for the initiative
+ */
+export const POLICY_SET_DEFINITION_SCHEMA_2021_06_01: ApiSchema = {
+  resourceType: "Microsoft.Authorization/policySetDefinitions",
+  version: "2021-06-01",
+  properties: {
+    ...COMMON_PROPERTIES,
+  },
+  required: ["displayName", "policyDefinitions"],
+  optional: [
+    "name",
+    "description",
+    "policyType",
+    "metadata",
+    "parameters",
+    "policyDefinitionGroups",
+  ],
+  deprecated: [],
+  transformationRules: {},
+  validationRules: [
+    {
+      property: "displayName",
+      rules: [
+        {
+          ruleType: ValidationRuleType.REQUIRED,
+          message: "Display name is required for policy set definitions",
+        },
+      ],
+    },
+    {
+      property: "policyDefinitions",
+      rules: [
+        {
+          ruleType: ValidationRuleType.REQUIRED,
+          message:
+            "Policy definitions array is required for policy set definitions",
+        },
+      ],
+    },
+  ],
+};
+
+// =============================================================================
+// VERSION CONFIGURATIONS
+// =============================================================================
+
+/**
+ * Version configuration for Policy Set Definition 2023-04-01
+ */
+export const POLICY_SET_DEFINITION_VERSION_2023_04_01: VersionConfig = {
+  version: "2023-04-01",
+  schema: POLICY_SET_DEFINITION_SCHEMA_2023_04_01,
+  supportLevel: VersionSupportLevel.ACTIVE,
+  releaseDate: "2023-04-01",
+  deprecationDate: undefined,
+  sunsetDate: undefined,
+  breakingChanges: [],
+  migrationGuide: "/docs/policy-set-definition/migration-2023-04-01",
+  changeLog: [
+    {
+      changeType: "updated",
+      description:
+        "Latest stable API version for Policy Set Definitions with enhanced validation",
+      breaking: false,
+    },
+  ],
+};
+
+/**
+ * Version configuration for Policy Set Definition 2021-06-01
+ */
+export const POLICY_SET_DEFINITION_VERSION_2021_06_01: VersionConfig = {
+  version: "2021-06-01",
+  schema: POLICY_SET_DEFINITION_SCHEMA_2021_06_01,
+  supportLevel: VersionSupportLevel.ACTIVE,
+  releaseDate: "2021-06-01",
+  deprecationDate: undefined,
+  sunsetDate: undefined,
+  breakingChanges: [],
+  migrationGuide: "/docs/policy-set-definition/migration-2021-06-01",
+  changeLog: [
+    {
+      changeType: "updated",
+      description: "Stable API version for backward compatibility",
+      breaking: false,
+    },
+  ],
+};
+
+/**
+ * All supported Policy Set Definition versions for registration
+ * Ordered with latest stable version first
+ */
+export const ALL_POLICY_SET_DEFINITION_VERSIONS: VersionConfig[] = [
+  POLICY_SET_DEFINITION_VERSION_2023_04_01,
+  POLICY_SET_DEFINITION_VERSION_2021_06_01,
+];
+
+/**
+ * Resource type constant
+ */
+export const POLICY_SET_DEFINITION_TYPE =
+  "Microsoft.Authorization/policySetDefinitions";

--- a/src/azure-policysetdefinition/lib/policy-set-definition.ts
+++ b/src/azure-policysetdefinition/lib/policy-set-definition.ts
@@ -1,0 +1,658 @@
+/**
+ * Unified Azure Policy Set Definition (Initiative) implementation using AzapiResource framework
+ *
+ * This class provides a version-aware implementation for Azure Policy Set Definitions
+ * that automatically handles version management, schema validation, and property
+ * transformation across all supported API versions.
+ *
+ * Policy Set Definitions (also known as Initiatives in Azure Portal) allow you to
+ * group multiple policy definitions together and assign them as a single unit.
+ *
+ * Supported API Versions:
+ * - 2023-04-01 (Active, Latest)
+ * - 2021-06-01 (Active, Backward Compatibility)
+ *
+ * Features:
+ * - Automatic latest version resolution when no version is specified
+ * - Explicit version pinning for stability requirements
+ * - Schema-driven validation and transformation
+ * - Full JSII compliance for multi-language support
+ * - Support for policy definition references with parameters
+ * - Policy definition groups for organization
+ * - Initiative-level parameter definitions
+ */
+
+import { createHash } from "crypto";
+import * as cdktf from "cdktf";
+import { Construct } from "constructs";
+import {
+  ALL_POLICY_SET_DEFINITION_VERSIONS,
+  POLICY_SET_DEFINITION_TYPE,
+} from "./policy-set-definition-schemas";
+import {
+  AzapiResource,
+  AzapiResourceProps,
+} from "../../core-azure/lib/azapi/azapi-resource";
+import { ApiSchema } from "../../core-azure/lib/version-manager/interfaces/version-interfaces";
+
+/**
+ * A reference to a policy definition within a policy set
+ *
+ * This defines which policy definitions are included in the initiative
+ * and how they are configured with parameters.
+ */
+export interface PolicyDefinitionReference {
+  /**
+   * The ID of the policy definition to include in the set
+   *
+   * This can be:
+   * - A built-in policy: /providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionId}
+   * - A custom policy at subscription level: /subscriptions/{subscriptionId}/providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionId}
+   * - A custom policy at management group level: /providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionId}
+   *
+   * @example "/providers/Microsoft.Authorization/policyDefinitions/06a78e20-9358-41c9-923c-fb736d382a4d"
+   */
+  readonly policyDefinitionId: string;
+
+  /**
+   * A unique identifier for this policy definition reference within the set
+   *
+   * This ID is used to reference this specific policy in the initiative
+   * and must be unique within the policy set definition.
+   *
+   * @example "auditVMsWithoutTags"
+   */
+  readonly policyDefinitionReferenceId?: string;
+
+  /**
+   * Parameter values for this policy definition
+   *
+   * These values override the default parameter values in the policy definition.
+   * Parameters can reference initiative-level parameters using the format:
+   * { "value": "[parameters('initiativeParameterName')]" }
+   *
+   * @example { "tagName": { "value": "environment" }, "tagValue": { "value": "[parameters('requiredTagValue')]" } }
+   */
+  readonly parameters?: { [key: string]: PolicyParameterValue };
+
+  /**
+   * Group names that this policy definition belongs to
+   *
+   * Groups help organize policies within an initiative and can be used
+   * for compliance reporting and management.
+   *
+   * @example ["Security", "Compliance"]
+   */
+  readonly groupNames?: string[];
+}
+
+/**
+ * A group for organizing policy definitions within a policy set
+ *
+ * Groups provide a way to categorize and organize policies within an initiative
+ * for better management and compliance reporting.
+ */
+export interface PolicyDefinitionGroup {
+  /**
+   * The name of the group (must be unique within the policy set)
+   *
+   * This name is referenced by policy definitions to indicate membership.
+   *
+   * @example "Security"
+   */
+  readonly name: string;
+
+  /**
+   * The display name of the group shown in Azure Portal
+   *
+   * @example "Security Policies"
+   */
+  readonly displayName?: string;
+
+  /**
+   * The category this group belongs to
+   *
+   * Categories help organize groups and are displayed in the Azure Portal.
+   *
+   * @example "Security Center"
+   */
+  readonly category?: string;
+
+  /**
+   * A description of the group's purpose
+   *
+   * @example "Policies related to security configuration and compliance"
+   */
+  readonly description?: string;
+
+  /**
+   * Additional metadata for the group
+   */
+  readonly additionalMetadataId?: string;
+}
+
+/**
+ * Metadata for the policy set definition
+ *
+ * Metadata provides additional information about the policy set
+ * without affecting its evaluation logic.
+ */
+export interface PolicySetMetadata {
+  /**
+   * The category of the policy set for Azure Portal organization
+   *
+   * @example "Security Center"
+   */
+  readonly category?: string;
+
+  /**
+   * The version of the policy set definition
+   *
+   * @example "1.0.0"
+   */
+  readonly version?: string;
+
+  /**
+   * Whether this policy set is in preview
+   *
+   * @default false
+   */
+  readonly preview?: boolean;
+
+  /**
+   * Whether this policy set is deprecated
+   *
+   * @default false
+   */
+  readonly deprecated?: boolean;
+}
+
+/**
+ * Metadata for a policy set parameter
+ *
+ * Provides additional information for Azure Portal integration.
+ */
+export interface PolicySetParameterMetadata {
+  /**
+   * Strong type for Azure Portal resource picker integration
+   */
+  readonly strongType?: string;
+
+  /**
+   * Display name in Azure Portal
+   */
+  readonly displayName?: string;
+
+  /**
+   * Description in Azure Portal
+   */
+  readonly description?: string;
+}
+
+/**
+ * Parameter definition for the policy set
+ *
+ * These parameters can be referenced by policy definitions within the set.
+ */
+export interface PolicySetParameterDefinition {
+  /**
+   * The data type of the parameter
+   */
+  readonly type:
+    | "String"
+    | "Array"
+    | "Object"
+    | "Boolean"
+    | "Integer"
+    | "Float"
+    | "DateTime";
+
+  /**
+   * Display name for the parameter in Azure Portal
+   */
+  readonly displayName?: string;
+
+  /**
+   * Description of the parameter
+   */
+  readonly description?: string;
+
+  /**
+   * Default value for the parameter
+   */
+  readonly defaultValue?: any;
+
+  /**
+   * Allowed values for the parameter
+   */
+  readonly allowedValues?: any[];
+
+  /**
+   * Metadata for the parameter (e.g., strongType for Azure Portal integration)
+   */
+  readonly metadata?: PolicySetParameterMetadata;
+}
+
+/**
+ * A parameter value, either a direct value or a reference
+ */
+export interface PolicyParameterValue {
+  /**
+   * The value of the parameter
+   *
+   * Can be a direct value or a reference to an initiative parameter
+   * using the format: "[parameters('parameterName')]"
+   */
+  readonly value: any;
+}
+
+/**
+ * Properties for the unified Azure Policy Set Definition
+ *
+ * Extends AzapiResourceProps with Policy Set Definition specific properties
+ */
+export interface PolicySetDefinitionProps extends AzapiResourceProps {
+  /**
+   * The scope at which to create the policy set definition
+   *
+   * This can be:
+   * - A subscription: /subscriptions/{subscriptionId}
+   * - A management group: /providers/Microsoft.Management/managementGroups/{managementGroupId}
+   *
+   * @example "/subscriptions/00000000-0000-0000-0000-000000000000"
+   * @example "/providers/Microsoft.Management/managementGroups/my-management-group"
+   */
+  readonly scope: string;
+
+  /**
+   * The display name of the policy set definition
+   *
+   * This is the name shown in the Azure Portal.
+   * Required property.
+   *
+   * @example "Security Baseline Initiative"
+   */
+  readonly displayName: string;
+
+  /**
+   * Description of the policy set definition
+   *
+   * @example "This initiative applies a set of security policies to ensure baseline compliance."
+   */
+  readonly description?: string;
+
+  /**
+   * The type of policy set definition
+   *
+   * @default "Custom"
+   */
+  readonly policyType?: "BuiltIn" | "Custom" | "Static";
+
+  /**
+   * Metadata for the policy set definition
+   *
+   * Includes category, version, preview, and deprecated flags.
+   */
+  readonly metadata?: PolicySetMetadata;
+
+  /**
+   * Parameter definitions for the policy set
+   *
+   * These parameters can be referenced by policy definitions in the set
+   * using the format: "[parameters('parameterName')]"
+   */
+  readonly parameters?: { [key: string]: PolicySetParameterDefinition };
+
+  /**
+   * Array of policy definition references
+   *
+   * Each reference specifies a policy definition to include in the set
+   * along with its parameter values and group memberships.
+   * Required property.
+   */
+  readonly policyDefinitions: PolicyDefinitionReference[];
+
+  /**
+   * Groups for organizing policy definitions in the set
+   *
+   * Groups help categorize policies for management and compliance reporting.
+   */
+  readonly policyDefinitionGroups?: PolicyDefinitionGroup[];
+}
+
+/**
+ * Properties interface for Azure Policy Set Definition
+ * This is required for JSII compliance to support multi-language code generation
+ */
+export interface PolicySetDefinitionProperties {
+  /**
+   * The display name of the policy set definition
+   */
+  readonly displayName: string;
+
+  /**
+   * Description of the policy set definition
+   */
+  readonly description?: string;
+
+  /**
+   * The type of policy set definition
+   */
+  readonly policyType?: string;
+
+  /**
+   * Metadata for the policy set definition
+   */
+  readonly metadata?: PolicySetMetadata;
+
+  /**
+   * Parameter definitions for the policy set
+   */
+  readonly parameters?: { [key: string]: PolicySetParameterDefinition };
+
+  /**
+   * Array of policy definition references
+   */
+  readonly policyDefinitions: PolicyDefinitionReference[];
+
+  /**
+   * Groups for organizing policy definitions
+   */
+  readonly policyDefinitionGroups?: PolicyDefinitionGroup[];
+}
+
+/**
+ * The resource body interface for Azure Policy Set Definition API calls
+ * This matches the Azure REST API schema for policy set definitions
+ */
+export interface PolicySetDefinitionBody {
+  /**
+   * The properties of the policy set definition
+   */
+  readonly properties: PolicySetDefinitionProperties;
+}
+
+/**
+ * Unified Azure Policy Set Definition (Initiative) implementation
+ *
+ * This class provides a single, version-aware implementation for managing Azure
+ * Policy Set Definitions. It automatically handles version resolution, schema validation,
+ * and property transformation.
+ *
+ * Policy Set Definitions allow you to group multiple policy definitions together
+ * and assign them as a single unit (also known as "Initiatives" in Azure Portal).
+ *
+ * Note: Policy set definitions are created at subscription or management group scope.
+ * They do not have a location property as they are not region-specific.
+ *
+ * @example
+ * const initiative = new PolicySetDefinition(this, "security-initiative", {
+ *   displayName: "Security Baseline",
+ *   scope: "/subscriptions/00000000-0000-0000-0000-000000000000",
+ *   policyDefinitions: [
+ *     {
+ *       policyDefinitionId: "/providers/Microsoft.Authorization/policyDefinitions/abc123",
+ *       policyDefinitionReferenceId: "auditVMsWithoutExtensions",
+ *     },
+ *   ],
+ * });
+ *
+ * @stability stable
+ */
+export class PolicySetDefinition extends AzapiResource {
+  static {
+    AzapiResource.registerSchemas(
+      POLICY_SET_DEFINITION_TYPE,
+      ALL_POLICY_SET_DEFINITION_VERSIONS,
+    );
+  }
+
+  /**
+   * The input properties for this Policy Set Definition instance
+   */
+  public readonly props: PolicySetDefinitionProps;
+
+  // Output properties for easy access and referencing
+  public readonly idOutput: cdktf.TerraformOutput;
+  public readonly nameOutput: cdktf.TerraformOutput;
+  public readonly policySetDefinitionIdOutput: cdktf.TerraformOutput;
+
+  /**
+   * Creates a new Azure Policy Set Definition using the AzapiResource framework
+   *
+   * The constructor automatically handles version resolution, schema registration,
+   * validation, and resource creation.
+   *
+   * @param scope - The scope in which to define this construct
+   * @param id - The unique identifier for this instance
+   * @param props - Configuration properties for the Policy Set Definition
+   */
+  constructor(scope: Construct, id: string, props: PolicySetDefinitionProps) {
+    // Validate required properties
+    if (!props.displayName || props.displayName.trim() === "") {
+      throw new Error("displayName is required for policy set definitions");
+    }
+
+    if (!props.policyDefinitions || props.policyDefinitions.length === 0) {
+      throw new Error(
+        "At least one policy definition reference is required in policyDefinitions",
+      );
+    }
+
+    // Validate policy definition references
+    props.policyDefinitions.forEach((policyDef, index) => {
+      if (!policyDef.policyDefinitionId) {
+        throw new Error(
+          `policyDefinitionId is required for policy definition at index ${index}`,
+        );
+      }
+    });
+
+    // Validate policy definition groups if provided
+    if (props.policyDefinitionGroups) {
+      const groupNames = new Set<string>();
+      props.policyDefinitionGroups.forEach((group, index) => {
+        if (!group.name) {
+          throw new Error(
+            `name is required for policy definition group at index ${index}`,
+          );
+        }
+        if (groupNames.has(group.name)) {
+          throw new Error(
+            `Duplicate group name '${group.name}' in policyDefinitionGroups`,
+          );
+        }
+        groupNames.add(group.name);
+      });
+
+      // Validate that policy definitions reference valid groups
+      const validGroupNames = Array.from(groupNames);
+      props.policyDefinitions.forEach((policyDef, index) => {
+        if (policyDef.groupNames) {
+          policyDef.groupNames.forEach((groupName) => {
+            if (!validGroupNames.includes(groupName)) {
+              throw new Error(
+                `Policy definition at index ${index} references unknown group '${groupName}'. Valid groups are: ${validGroupNames.join(", ")}`,
+              );
+            }
+          });
+        }
+      });
+    }
+
+    super(scope, id, props);
+
+    this.props = props;
+
+    // Create Terraform outputs for easy access and referencing from other resources
+    this.idOutput = new cdktf.TerraformOutput(this, "id", {
+      value: this.id,
+      description: "The ID of the Policy Set Definition",
+    });
+
+    this.nameOutput = new cdktf.TerraformOutput(this, "name", {
+      value: `\${${this.terraformResource.fqn}.name}`,
+      description: "The name of the Policy Set Definition",
+    });
+
+    this.policySetDefinitionIdOutput = new cdktf.TerraformOutput(
+      this,
+      "policy_set_definition_id",
+      {
+        value: this.id,
+        description:
+          "The Policy Set Definition ID (same as id, for use in policy assignments)",
+      },
+    );
+
+    // Override logical IDs to match original naming convention
+    this.idOutput.overrideLogicalId("id");
+    this.nameOutput.overrideLogicalId("name");
+    this.policySetDefinitionIdOutput.overrideLogicalId(
+      "policy_set_definition_id",
+    );
+  }
+
+  // =============================================================================
+  // REQUIRED ABSTRACT METHODS FROM AzapiResource
+  // =============================================================================
+
+  /**
+   * Gets the default API version to use when no explicit version is specified
+   * Returns the most recent stable version as the default
+   */
+  protected defaultVersion(): string {
+    return "2023-04-01";
+  }
+
+  /**
+   * Gets the Azure resource type for Policy Set Definitions
+   */
+  protected resourceType(): string {
+    return POLICY_SET_DEFINITION_TYPE;
+  }
+
+  /**
+   * Gets the API schema for the resolved version
+   * Uses the framework's schema resolution to get the appropriate schema
+   */
+  protected apiSchema(): ApiSchema {
+    return this.resolveSchema();
+  }
+
+  /**
+   * Overrides the name resolution to generate deterministic GUIDs for policy set definitions
+   *
+   * Policy set definitions can use custom names or auto-generated GUIDs.
+   * This implementation generates a deterministic UUID based on the policy set definition's
+   * key properties if no name is provided.
+   */
+  protected resolveName(props: AzapiResourceProps): string {
+    const typedProps = props as PolicySetDefinitionProps;
+
+    // If name is provided, use it
+    if (typedProps.name) {
+      return typedProps.name;
+    }
+
+    // Generate a deterministic GUID based on display name and scope
+    const hashInput = [typedProps.displayName, typedProps.scope].join("|");
+
+    const hash = createHash("sha256").update(hashInput).digest("hex");
+
+    // Convert hash to UUID format (8-4-4-4-12)
+    return [
+      hash.substring(0, 8),
+      hash.substring(8, 12),
+      hash.substring(12, 16),
+      hash.substring(16, 20),
+      hash.substring(20, 32),
+    ].join("-");
+  }
+
+  /**
+   * Creates the resource body for the Azure API call
+   * Transforms the input properties into the JSON format expected by Azure REST API
+   *
+   * Note: Policy set definitions do not have a location property as they are
+   * scope-specific resources deployed at subscription or management group level.
+   */
+  protected createResourceBody(props: any): any {
+    const typedProps = props as PolicySetDefinitionProps;
+
+    const body: any = {
+      properties: {
+        displayName: typedProps.displayName,
+        policyType: typedProps.policyType || "Custom",
+        policyDefinitions: typedProps.policyDefinitions,
+      },
+    };
+
+    // Add optional properties only if specified
+    if (typedProps.description) {
+      body.properties.description = typedProps.description;
+    }
+
+    if (typedProps.metadata) {
+      body.properties.metadata = typedProps.metadata;
+    }
+
+    if (typedProps.parameters) {
+      body.properties.parameters = typedProps.parameters;
+    }
+
+    if (
+      typedProps.policyDefinitionGroups &&
+      typedProps.policyDefinitionGroups.length > 0
+    ) {
+      body.properties.policyDefinitionGroups =
+        typedProps.policyDefinitionGroups;
+    }
+
+    return body;
+  }
+
+  /**
+   * Resolves the parent resource ID for Policy Set Definition
+   * Policy Set Definitions are created at subscription or management group scope
+   *
+   * @param props - The resource properties
+   * @returns The parent resource ID (the scope)
+   */
+  protected resolveParentId(props: any): string {
+    return (props as PolicySetDefinitionProps).scope;
+  }
+
+  // =============================================================================
+  // PUBLIC METHODS FOR POLICY SET DEFINITION OPERATIONS
+  // =============================================================================
+
+  /**
+   * Get the full resource identifier for use in policy assignments
+   * Alias for the id property
+   */
+  public get policySetDefinitionId(): string {
+    return this.id;
+  }
+
+  /**
+   * Get the display name of the policy set definition
+   */
+  public get displayName(): string {
+    return this.props.displayName;
+  }
+
+  /**
+   * Get the policy type
+   */
+  public get policyType(): string {
+    return this.props.policyType || "Custom";
+  }
+
+  /**
+   * Get the number of policy definitions in this set
+   */
+  public get policyDefinitionCount(): number {
+    return this.props.policyDefinitions.length;
+  }
+}

--- a/src/azure-policysetdefinition/test/policy-set-definition.integ.ts
+++ b/src/azure-policysetdefinition/test/policy-set-definition.integ.ts
@@ -1,0 +1,67 @@
+/**
+ * Integration test for Azure Policy Set Definition (Initiative)
+ *
+ * This test demonstrates basic usage of the PolicySetDefinition construct
+ * and validates deployment, idempotency, and cleanup.
+ *
+ * Run with: npm run integration:nostream
+ */
+
+import { Testing, TerraformStack } from "cdktf";
+import { Construct } from "constructs";
+import "cdktf/lib/testing/adapters/jest";
+import { DataAzapiClientConfig } from "../../core-azure/lib/azapi/providers-azapi/data-azapi-client-config";
+import { AzapiProvider } from "../../core-azure/lib/azapi/providers-azapi/provider";
+import { TerraformApplyCheckAndDestroy } from "../../testing";
+import { PolicySetDefinition } from "../lib/policy-set-definition";
+
+/**
+ * Example stack demonstrating Policy Set Definition usage
+ */
+class PolicySetDefinitionExampleStack extends TerraformStack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    // Configure AZAPI provider
+    new AzapiProvider(this, "azapi", {});
+
+    // Create a client config to get the current subscription ID
+    const clientConfig = new DataAzapiClientConfig(this, "client_config", {});
+
+    // Use the current subscription for policy definitions
+    const subscriptionId = `/subscriptions/\${${clientConfig.fqn}.subscription_id}`;
+
+    // Basic Policy Set Definition with built-in policies
+    new PolicySetDefinition(this, "basic-initiative", {
+      displayName: "Basic Security Initiative",
+      description:
+        "A simple initiative to demonstrate Policy Set Definition construct",
+      scope: subscriptionId,
+      policyDefinitions: [
+        {
+          // Audit VMs that do not use managed disks
+          policyDefinitionId:
+            "/providers/Microsoft.Authorization/policyDefinitions/06a78e20-9358-41c9-923c-fb736d382a4d",
+          policyDefinitionReferenceId: "auditManagedDisks",
+        },
+      ],
+    });
+  }
+}
+
+describe("Policy Set Definition Integration Test", () => {
+  it("should deploy, validate idempotency, and cleanup Policy Set Definition resources", () => {
+    const app = Testing.app();
+    const stack = new PolicySetDefinitionExampleStack(
+      app,
+      "test-policy-set-definition",
+    );
+    const synthesized = Testing.fullSynth(stack);
+
+    // This will:
+    // 1. Run terraform apply to deploy resources
+    // 2. Run terraform plan to check idempotency (no changes expected)
+    // 3. Run terraform destroy to cleanup resources
+    TerraformApplyCheckAndDestroy(synthesized);
+  }, 600000); // 10 minute timeout for deployment and cleanup
+});

--- a/src/azure-policysetdefinition/test/policy-set-definition.spec.ts
+++ b/src/azure-policysetdefinition/test/policy-set-definition.spec.ts
@@ -1,0 +1,947 @@
+/**
+ * Comprehensive tests for the PolicySetDefinition implementation
+ *
+ * This test suite validates the PolicySetDefinition class using the AzapiResource framework.
+ * Tests cover automatic version resolution, explicit version pinning, schema validation,
+ * property configurations, and resource creation.
+ */
+
+import { Testing } from "cdktf";
+import * as cdktf from "cdktf";
+import {
+  PolicySetDefinition,
+  PolicySetDefinitionProps,
+} from "../lib/policy-set-definition";
+
+describe("PolicySetDefinition - Implementation", () => {
+  let app: cdktf.App;
+  let stack: cdktf.TerraformStack;
+
+  beforeEach(() => {
+    app = Testing.app();
+    stack = new cdktf.TerraformStack(app, "TestStack");
+  });
+
+  // =============================================================================
+  // Constructor and Basic Properties
+  // =============================================================================
+
+  describe("Constructor and Basic Properties", () => {
+    it("should create a Policy Set Definition with minimal configuration", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Test Initiative",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/test-policy-id",
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(stack, "TestPolicySet", props);
+
+      expect(policySet).toBeInstanceOf(PolicySetDefinition);
+      expect(policySet.props).toBe(props);
+      expect(policySet.displayName).toBe("Test Initiative");
+      expect(policySet.policyType).toBe("Custom");
+      expect(policySet.policyDefinitionCount).toBe(1);
+    });
+
+    it("should create a Policy Set Definition with description", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Security Initiative",
+        description: "Initiative for security compliance",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(
+        stack,
+        "SecurityPolicySet",
+        props,
+      );
+
+      expect(policySet.props.description).toBe(
+        "Initiative for security compliance",
+      );
+    });
+
+    it("should create a Policy Set Definition with custom name", () => {
+      const props: PolicySetDefinitionProps = {
+        name: "my-custom-initiative",
+        displayName: "Custom Named Initiative",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(
+        stack,
+        "CustomNamedPolicySet",
+        props,
+      );
+
+      expect(policySet.props.name).toBe("my-custom-initiative");
+    });
+
+    it("should create a Policy Set Definition with metadata", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Metadata Initiative",
+        scope: "/subscriptions/test-sub",
+        metadata: {
+          category: "Security Center",
+          version: "1.0.0",
+          preview: false,
+          deprecated: false,
+        },
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(
+        stack,
+        "MetadataPolicySet",
+        props,
+      );
+
+      expect(policySet.props.metadata?.category).toBe("Security Center");
+      expect(policySet.props.metadata?.version).toBe("1.0.0");
+      expect(policySet.props.metadata?.preview).toBe(false);
+    });
+  });
+
+  // =============================================================================
+  // Version Resolution
+  // =============================================================================
+
+  describe("Version Resolution", () => {
+    it("should use latest version 2023-04-01 when no version specified", () => {
+      const policySet = new PolicySetDefinition(stack, "DefaultVersion", {
+        displayName: "Default Version Initiative",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      });
+
+      expect(policySet.resolvedApiVersion).toBe("2023-04-01");
+    });
+
+    it("should use explicit version when specified", () => {
+      const policySet = new PolicySetDefinition(stack, "PinnedVersion", {
+        displayName: "Pinned Version Initiative",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+        apiVersion: "2021-06-01",
+      });
+
+      expect(policySet.resolvedApiVersion).toBe("2021-06-01");
+    });
+
+    it("should use latest version 2023-04-01 when explicitly specified", () => {
+      const policySet = new PolicySetDefinition(stack, "LatestVersion", {
+        displayName: "Latest Version Initiative",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+        apiVersion: "2023-04-01",
+      });
+
+      expect(policySet.resolvedApiVersion).toBe("2023-04-01");
+    });
+  });
+
+  // =============================================================================
+  // Validation Tests
+  // =============================================================================
+
+  describe("Validation", () => {
+    it("should throw error when displayName is empty", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      };
+
+      expect(() => {
+        new PolicySetDefinition(stack, "EmptyDisplayName", props);
+      }).toThrow(/displayName is required/);
+    });
+
+    it("should throw error when policyDefinitions is empty", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "No Policies Initiative",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [],
+      };
+
+      expect(() => {
+        new PolicySetDefinition(stack, "NoPolicies", props);
+      }).toThrow(/At least one policy definition reference is required/);
+    });
+
+    it("should throw error when policyDefinitionId is missing", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Invalid Policy Reference",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId: "",
+          },
+        ],
+      };
+
+      expect(() => {
+        new PolicySetDefinition(stack, "InvalidPolicyRef", props);
+      }).toThrow(/policyDefinitionId is required/);
+    });
+
+    it("should throw error for duplicate group names", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Duplicate Groups",
+        scope: "/subscriptions/test-sub",
+        policyDefinitionGroups: [
+          { name: "Security", displayName: "Security Policies" },
+          { name: "Security", displayName: "Duplicate Security" },
+        ],
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      };
+
+      expect(() => {
+        new PolicySetDefinition(stack, "DuplicateGroups", props);
+      }).toThrow(/Duplicate group name 'Security'/);
+    });
+
+    it("should throw error for invalid group reference in policy definition", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Invalid Group Reference",
+        scope: "/subscriptions/test-sub",
+        policyDefinitionGroups: [
+          { name: "Security", displayName: "Security Policies" },
+        ],
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+            groupNames: ["NonExistentGroup"],
+          },
+        ],
+      };
+
+      expect(() => {
+        new PolicySetDefinition(stack, "InvalidGroupRef", props);
+      }).toThrow(/references unknown group 'NonExistentGroup'/);
+    });
+
+    it("should accept valid policy set with groups", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Valid Groups Initiative",
+        scope: "/subscriptions/test-sub",
+        policyDefinitionGroups: [
+          { name: "Security", displayName: "Security Policies" },
+          { name: "Compliance", displayName: "Compliance Policies" },
+        ],
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+            groupNames: ["Security"],
+          },
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-2",
+            groupNames: ["Security", "Compliance"],
+          },
+        ],
+      };
+
+      expect(() => {
+        new PolicySetDefinition(stack, "ValidGroups", props);
+      }).not.toThrow();
+    });
+  });
+
+  // =============================================================================
+  // Policy Definition References
+  // =============================================================================
+
+  describe("Policy Definition References", () => {
+    it("should create initiative with single policy definition", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Single Policy Initiative",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+            policyDefinitionReferenceId: "allowedLocations",
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(stack, "SinglePolicy", props);
+      expect(policySet.policyDefinitionCount).toBe(1);
+    });
+
+    it("should create initiative with multiple policy definitions", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Multiple Policy Initiative",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+            policyDefinitionReferenceId: "policy1",
+          },
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-2",
+            policyDefinitionReferenceId: "policy2",
+          },
+          {
+            policyDefinitionId:
+              "/subscriptions/sub-id/providers/Microsoft.Authorization/policyDefinitions/custom-policy",
+            policyDefinitionReferenceId: "customPolicy",
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(
+        stack,
+        "MultiplePolicies",
+        props,
+      );
+      expect(policySet.policyDefinitionCount).toBe(3);
+    });
+
+    it("should create initiative with policy parameters", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Parameterized Initiative",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+            policyDefinitionReferenceId: "tagPolicy",
+            parameters: {
+              tagName: { value: "environment" },
+              tagValue: { value: "production" },
+            },
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(
+        stack,
+        "ParameterizedPolicy",
+        props,
+      );
+      expect(
+        policySet.props.policyDefinitions[0].parameters?.tagName.value,
+      ).toBe("environment");
+    });
+  });
+
+  // =============================================================================
+  // Initiative Parameters
+  // =============================================================================
+
+  describe("Initiative Parameters", () => {
+    it("should create initiative with parameter definitions", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Initiative With Parameters",
+        scope: "/subscriptions/test-sub",
+        parameters: {
+          allowedLocations: {
+            type: "Array",
+            displayName: "Allowed Locations",
+            description: "List of allowed Azure regions",
+            defaultValue: ["eastus", "westus2"],
+            allowedValues: [["eastus"], ["westus2"], ["eastus", "westus2"]],
+          },
+          requiredTag: {
+            type: "String",
+            displayName: "Required Tag",
+            description: "Name of the required tag",
+            defaultValue: "environment",
+          },
+        },
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+            parameters: {
+              listOfAllowedLocations: {
+                value: "[parameters('allowedLocations')]",
+              },
+            },
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(stack, "WithParams", props);
+      expect(policySet.props.parameters?.allowedLocations.type).toBe("Array");
+      expect(policySet.props.parameters?.requiredTag.type).toBe("String");
+    });
+
+    it("should create initiative with strong typed parameter", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Strong Typed Parameters",
+        scope: "/subscriptions/test-sub",
+        parameters: {
+          storageAccountSku: {
+            type: "String",
+            displayName: "Storage Account SKU",
+            metadata: {
+              strongType: "storageSkus",
+              displayName: "Storage SKU",
+            },
+          },
+        },
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(
+        stack,
+        "StrongTypedParams",
+        props,
+      );
+      expect(
+        policySet.props.parameters?.storageAccountSku.metadata?.strongType,
+      ).toBe("storageSkus");
+    });
+  });
+
+  // =============================================================================
+  // Policy Definition Groups
+  // =============================================================================
+
+  describe("Policy Definition Groups", () => {
+    it("should create initiative with groups", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Grouped Policies Initiative",
+        scope: "/subscriptions/test-sub",
+        policyDefinitionGroups: [
+          {
+            name: "Security",
+            displayName: "Security Policies",
+            category: "Security Center",
+            description: "Policies related to security",
+          },
+          {
+            name: "Compliance",
+            displayName: "Compliance Policies",
+            category: "Regulatory Compliance",
+          },
+        ],
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+            groupNames: ["Security"],
+          },
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-2",
+            groupNames: ["Compliance"],
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(
+        stack,
+        "GroupedPolicies",
+        props,
+      );
+      expect(policySet.props.policyDefinitionGroups?.length).toBe(2);
+      expect(policySet.props.policyDefinitionGroups?.[0].name).toBe("Security");
+    });
+
+    it("should allow policy definitions in multiple groups", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Multi-Group Policy Initiative",
+        scope: "/subscriptions/test-sub",
+        policyDefinitionGroups: [
+          { name: "Security" },
+          { name: "Compliance" },
+          { name: "Operations" },
+        ],
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+            groupNames: ["Security", "Compliance"],
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(
+        stack,
+        "MultiGroupPolicy",
+        props,
+      );
+      expect(policySet.props.policyDefinitions[0].groupNames?.length).toBe(2);
+    });
+  });
+
+  // =============================================================================
+  // Property Transformation
+  // =============================================================================
+
+  describe("Property Transformation", () => {
+    it("should generate correct Azure API format via createResourceBody", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Transform Test Initiative",
+        description: "Test transformation",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+            policyDefinitionReferenceId: "policy1",
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(stack, "TransformTest", props);
+
+      // Access the protected createResourceBody method
+      const resourceBody = (policySet as any).createResourceBody(props);
+
+      expect(resourceBody).toHaveProperty("properties");
+      expect(resourceBody.properties).toHaveProperty(
+        "displayName",
+        "Transform Test Initiative",
+      );
+      expect(resourceBody.properties).toHaveProperty(
+        "description",
+        "Test transformation",
+      );
+      expect(resourceBody.properties).toHaveProperty("policyType", "Custom");
+      expect(resourceBody.properties.policyDefinitions).toHaveLength(1);
+    });
+
+    it("should include metadata when specified", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Metadata Test",
+        scope: "/subscriptions/test-sub",
+        metadata: {
+          category: "Testing",
+          version: "2.0.0",
+        },
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(stack, "MetadataTest", props);
+      const resourceBody = (policySet as any).createResourceBody(props);
+
+      expect(resourceBody.properties.metadata).toBeDefined();
+      expect(resourceBody.properties.metadata.category).toBe("Testing");
+    });
+
+    it("should include parameters when specified", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Parameters Test",
+        scope: "/subscriptions/test-sub",
+        parameters: {
+          testParam: {
+            type: "String",
+            defaultValue: "test",
+          },
+        },
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(stack, "ParametersTest", props);
+      const resourceBody = (policySet as any).createResourceBody(props);
+
+      expect(resourceBody.properties.parameters).toBeDefined();
+      expect(resourceBody.properties.parameters.testParam.type).toBe("String");
+    });
+
+    it("should include policyDefinitionGroups when specified", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Groups Test",
+        scope: "/subscriptions/test-sub",
+        policyDefinitionGroups: [
+          { name: "TestGroup", displayName: "Test Group" },
+        ],
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+            groupNames: ["TestGroup"],
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(stack, "GroupsTest", props);
+      const resourceBody = (policySet as any).createResourceBody(props);
+
+      expect(resourceBody.properties.policyDefinitionGroups).toBeDefined();
+      expect(resourceBody.properties.policyDefinitionGroups).toHaveLength(1);
+    });
+  });
+
+  // =============================================================================
+  // Integration with Base Class
+  // =============================================================================
+
+  describe("Integration with Base Class", () => {
+    it("should inherit from AzapiResource", () => {
+      const policySet = new PolicySetDefinition(stack, "InheritanceTest", {
+        displayName: "Inheritance Test",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      });
+
+      // Verify it has AzapiResource properties
+      expect(policySet).toHaveProperty("terraformResource");
+      expect(policySet).toHaveProperty("resolvedApiVersion");
+    });
+
+    it("should have correct resourceType", () => {
+      const policySet = new PolicySetDefinition(stack, "ResourceTypeTest", {
+        displayName: "Resource Type Test",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      });
+
+      // Access the protected resourceType method
+      const resourceType = (policySet as any).resourceType();
+      expect(resourceType).toBe("Microsoft.Authorization/policySetDefinitions");
+    });
+
+    it("should resolve parent ID correctly", () => {
+      const scope = "/subscriptions/test-sub";
+
+      const props: PolicySetDefinitionProps = {
+        displayName: "Parent ID Test",
+        scope,
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(stack, "ParentIdTest", props);
+
+      // Access the protected resolveParentId method
+      const parentId = (policySet as any).resolveParentId(props);
+      expect(parentId).toBe(scope);
+    });
+
+    it("should generate resource outputs", () => {
+      const policySet = new PolicySetDefinition(stack, "OutputsTest", {
+        displayName: "Outputs Test",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      });
+
+      expect(policySet.idOutput).toBeInstanceOf(cdktf.TerraformOutput);
+      expect(policySet.nameOutput).toBeInstanceOf(cdktf.TerraformOutput);
+      expect(policySet.policySetDefinitionIdOutput).toBeInstanceOf(
+        cdktf.TerraformOutput,
+      );
+      expect(policySet.id).toMatch(/^\$\{.*\.id\}$/);
+    });
+  });
+
+  // =============================================================================
+  // CDK Terraform Integration
+  // =============================================================================
+
+  describe("CDK Terraform Integration", () => {
+    it("should synthesize to valid Terraform configuration", () => {
+      new PolicySetDefinition(stack, "SynthTest", {
+        displayName: "Synth Test Initiative",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+            policyDefinitionReferenceId: "testPolicy",
+          },
+        ],
+      });
+
+      const synthesized = Testing.synth(stack);
+      expect(synthesized).toBeDefined();
+
+      const stackConfig = JSON.parse(synthesized);
+      expect(stackConfig.resource).toBeDefined();
+    });
+
+    it("should handle multiple policy sets in the same stack", () => {
+      const policySet1 = new PolicySetDefinition(stack, "PolicySet1", {
+        displayName: "Policy Set 1",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      });
+
+      const policySet2 = new PolicySetDefinition(stack, "PolicySet2", {
+        displayName: "Policy Set 2",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-2",
+          },
+        ],
+        apiVersion: "2021-06-01",
+      });
+
+      expect(policySet1.resolvedApiVersion).toBe("2023-04-01");
+      expect(policySet2.resolvedApiVersion).toBe("2021-06-01");
+
+      const synthesized = Testing.synth(stack);
+      expect(synthesized).toBeDefined();
+    });
+  });
+
+  // =============================================================================
+  // Complex Scenarios
+  // =============================================================================
+
+  describe("Complex Scenarios", () => {
+    it("should handle comprehensive initiative configuration", () => {
+      const props: PolicySetDefinitionProps = {
+        name: "comprehensive-initiative",
+        displayName: "Comprehensive Security & Compliance Initiative",
+        description:
+          "This initiative enforces security and compliance policies across the organization.",
+        scope: "/providers/Microsoft.Management/managementGroups/my-mg",
+        policyType: "Custom",
+        metadata: {
+          category: "Security Center",
+          version: "3.0.0",
+          preview: false,
+          deprecated: false,
+        },
+        parameters: {
+          allowedLocations: {
+            type: "Array",
+            displayName: "Allowed Locations",
+            description: "The list of allowed Azure regions",
+            defaultValue: ["eastus", "westus2", "centralus"],
+            metadata: {
+              strongType: "location",
+              displayName: "Locations",
+            },
+          },
+          requiredTagName: {
+            type: "String",
+            displayName: "Required Tag Name",
+            defaultValue: "costCenter",
+          },
+          effect: {
+            type: "String",
+            displayName: "Effect",
+            description: "The effect of the policy",
+            defaultValue: "Audit",
+            allowedValues: ["Audit", "Deny", "Disabled"],
+          },
+        },
+        policyDefinitionGroups: [
+          {
+            name: "Security",
+            displayName: "Security Policies",
+            category: "Security Center",
+            description: "Policies ensuring security best practices",
+          },
+          {
+            name: "Compliance",
+            displayName: "Compliance Policies",
+            category: "Regulatory Compliance",
+            description: "Policies for regulatory compliance",
+          },
+          {
+            name: "Tagging",
+            displayName: "Tagging Policies",
+            category: "Tags",
+            description: "Policies for consistent resource tagging",
+          },
+        ],
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/e56962a6-4747-49cd-b67b-bf8b01975c4c",
+            policyDefinitionReferenceId: "allowedLocations",
+            parameters: {
+              listOfAllowedLocations: {
+                value: "[parameters('allowedLocations')]",
+              },
+            },
+            groupNames: ["Security", "Compliance"],
+          },
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/96670d01-0a4d-4649-9c89-2d3abc0a5025",
+            policyDefinitionReferenceId: "requireTag",
+            parameters: {
+              tagName: { value: "[parameters('requiredTagName')]" },
+            },
+            groupNames: ["Tagging"],
+          },
+          {
+            policyDefinitionId:
+              "/subscriptions/test-sub/providers/Microsoft.Authorization/policyDefinitions/custom-security-policy",
+            policyDefinitionReferenceId: "customSecurityPolicy",
+            parameters: {
+              effect: { value: "[parameters('effect')]" },
+            },
+            groupNames: ["Security"],
+          },
+        ],
+        tags: {
+          environment: "production",
+          team: "security",
+          managedBy: "terraform-cdk",
+        },
+      };
+
+      const policySet = new PolicySetDefinition(
+        stack,
+        "ComprehensiveConfig",
+        props,
+      );
+      const resourceBody = (policySet as any).createResourceBody(props);
+
+      expect(resourceBody.properties.displayName).toBe(
+        "Comprehensive Security & Compliance Initiative",
+      );
+      expect(resourceBody.properties.policyType).toBe("Custom");
+      expect(resourceBody.properties.metadata.category).toBe("Security Center");
+      expect(resourceBody.properties.parameters.allowedLocations.type).toBe(
+        "Array",
+      );
+      expect(resourceBody.properties.policyDefinitionGroups).toHaveLength(3);
+      expect(resourceBody.properties.policyDefinitions).toHaveLength(3);
+      expect(resourceBody.properties.policyDefinitions[0].groupNames).toContain(
+        "Security",
+      );
+    });
+
+    it("should handle management group scope", () => {
+      const mgScope =
+        "/providers/Microsoft.Management/managementGroups/my-management-group";
+
+      const props: PolicySetDefinitionProps = {
+        displayName: "Management Group Initiative",
+        scope: mgScope,
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(
+        stack,
+        "MgScopeInitiative",
+        props,
+      );
+      const parentId = (policySet as any).resolveParentId(props);
+
+      expect(parentId).toBe(mgScope);
+    });
+
+    it("should handle subscription scope", () => {
+      const subScope = "/subscriptions/00000000-0000-0000-0000-000000000000";
+
+      const props: PolicySetDefinitionProps = {
+        displayName: "Subscription Initiative",
+        scope: subScope,
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(
+        stack,
+        "SubScopeInitiative",
+        props,
+      );
+      const parentId = (policySet as any).resolveParentId(props);
+
+      expect(parentId).toBe(subScope);
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@
  * - azure_actiongroup: Azure Action Group constructs for Azure Monitor alerts
  * - azure_activitylogalert: Azure Activity Log Alert constructs for operation monitoring
  * - azure_aks: Azure Kubernetes Service constructs with version-aware AZAPI implementation
+ * - azure_loganalyticsworkspace: Log Analytics Workspace constructs for log data collection
  * - azure_diagnosticsettings: Azure Diagnostic Settings constructs for monitoring and observability
  * - azure_dnsforwardingruleset: DNS Forwarding Ruleset constructs for private DNS resolution
  * - azure_dnsresolver: DNS Resolver constructs for private DNS resolution
@@ -16,8 +17,10 @@
  * - azure_metricalert: Azure Metric Alert constructs for metric-based alerting
  * - azure_networkinterface: Network Interface constructs with version-aware AZAPI implementation
  * - azure_networksecuritygroup: Network Security Group constructs with version-aware AZAPI implementation
+ * - azure_networkwatcher: Network Watcher constructs for network monitoring and diagnostics
  * - azure_policyassignment: Policy Assignment constructs for Azure Policy
  * - azure_policydefinition: Policy Definition constructs for custom Azure policies
+ * - azure_policysetdefinition: Policy Set Definition (Initiative) constructs for grouping policies
  * - azure_privatednszone: Private DNS Zone constructs with DNS record management
  * - azure_privatednszonelink: Private DNS Zone Link constructs for VNet linking
  * - azure_publicipaddress: Public IP Address constructs with version-aware AZAPI implementation
@@ -51,13 +54,16 @@ export * as azure_activitylogalert from "./azure-activitylogalert";
 export * as azure_aks from "./azure-aks";
 export * as azure_diagnosticsettings from "./azure-diagnosticsettings";
 export * as azure_dnsforwardingruleset from "./azure-dnsforwardingruleset";
+export * as azure_loganalyticsworkspace from "./azure-loganalyticsworkspace";
 export * as azure_dnsresolver from "./azure-dnsresolver";
 export * as azure_dnszone from "./azure-dnszone";
 export * as azure_metricalert from "./azure-metricalert";
 export * as azure_networkinterface from "./azure-networkinterface";
 export * as azure_networksecuritygroup from "./azure-networksecuritygroup";
+export * as azure_networkwatcher from "./azure-networkwatcher";
 export * as azure_policyassignment from "./azure-policyassignment";
 export * as azure_policydefinition from "./azure-policydefinition";
+export * as azure_policysetdefinition from "./azure-policysetdefinition";
 export * as azure_privatednszone from "./azure-privatednszone";
 export * as azure_privatednszonelink from "./azure-privatednszonelink";
 export * as azure_publicipaddress from "./azure-publicipaddress";
@@ -80,12 +86,15 @@ export * from "./azure-aks";
 export * from "./azure-diagnosticsettings";
 export * from "./azure-dnsforwardingruleset";
 export * from "./azure-dnsresolver";
+export * from "./azure-loganalyticsworkspace";
 export * from "./azure-dnszone";
 export * from "./azure-metricalert";
 export * from "./azure-networkinterface";
 export * from "./azure-networksecuritygroup";
+export * from "./azure-networkwatcher";
 export * from "./azure-policyassignment";
 export * from "./azure-policydefinition";
+export * from "./azure-policysetdefinition";
 export * from "./azure-privatednszone";
 export * from "./azure-privatednszonelink";
 export * from "./azure-publicipaddress";

--- a/yarn.lock
+++ b/yarn.lock
@@ -810,7 +810,7 @@
 
 "@types/uuid@^10.0.0":
   version "10.0.0"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-10.0.0.tgz#e9c07fe50da0f53dc24970cca94d619ff03f6f6d"
+  resolved "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz"
   integrity sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==
 
 "@types/yargs-parser@*":
@@ -1144,9 +1144,9 @@ available-typed-arrays@^1.0.5:
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
 b4a@^1.6.4:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.7.3.tgz#24cf7ccda28f5465b66aec2bac69e32809bf112f"
-  integrity sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.8.0.tgz#1ca3ba0edc9469aaabef5647e769a83d50180b1a"
+  integrity sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==
 
 babel-jest@^29.7.0:
   version "29.7.0"
@@ -1214,9 +1214,9 @@ balanced-match@^1.0.0:
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 bare-events@^2.7.0:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/bare-events/-/bare-events-2.8.1.tgz#121afaeee9e9a8eb92e71d125bc85753d39913d0"
-  integrity sha512-oxSAxTS1hRfnyit2CL5QpAOS5ixfBjj6ex3yTNvXyY/kE719jQ/IjuESJBK2w5v4wwQRAHGseVJXx9QBYOtFGQ==
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/bare-events/-/bare-events-2.8.2.tgz#7b3e10bd8e1fc80daf38bb516921678f566ab89f"
+  integrity sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==
 
 baseline-browser-mapping@^2.8.19:
   version "2.8.20"
@@ -4158,7 +4158,7 @@ readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.0.2, readable-stre
 
 readable-stream@^2.0.5, readable-stream@~2.3.6:
   version "2.3.8"
-  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
   integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
   dependencies:
     core-util-is "~1.0.0"
@@ -4687,9 +4687,9 @@ test-exclude@^6.0.0:
     minimatch "^3.0.4"
 
 text-decoder@^1.1.0:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/text-decoder/-/text-decoder-1.2.3.tgz#b19da364d981b2326d5f43099c310cc80d770c65"
-  integrity sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/text-decoder/-/text-decoder-1.2.7.tgz#5d073a9a74b9c0a9d28dfadcab96b604af57d8ba"
+  integrity sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==
   dependencies:
     b4a "^1.6.4"
 
@@ -4937,7 +4937,7 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
 
 uuid@^11.0.3:
   version "11.1.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
+  resolved "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz"
   integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
 
 uuid@^8.3.2:


### PR DESCRIPTION
## Summary

This PR adds three new Azure constructs to the library:

### 1. Log Analytics Workspace (`azure-loganalyticsworkspace`)
- Resource Type: `Microsoft.OperationalInsights/workspaces`
- API Versions: 2023-09-01, 2022-10-01
- Features: Retention config, SKU options, workspace capping, network access controls

### 2. Network Watcher (`azure-networkwatcher`)
- Resource Type: `Microsoft.Network/networkWatchers`
- API Versions: 2024-01-01, 2023-11-01
- Note: One per region per subscription

### 3. Policy Set Definition (`azure-policysetdefinition`)
- Resource Type: `Microsoft.Authorization/policySetDefinitions`
- API Versions: 2023-04-01, 2021-06-01
- Features: Policy definition references, groups, parameters

## Testing
- ✅ 86 unit tests passing
- ✅ TypeScript/JSII compilation successful
- ✅ Integration tests pass (Network Watcher limited by Azure's 1-per-region constraint)