### PR TITLE
feat: add Log Analytics Workspace, Network Watcher, and Policy Set Definition constructs

### DIFF
--- a/src/azure-loganalyticsworkspace/README.md
+++ b/src/azure-loganalyticsworkspace/README.md
@@ -1,0 +1,369 @@
+# Azure Log Analytics Workspace Construct
+
+This module provides a high-level TypeScript construct for managing Azure Log Analytics Workspaces using the Terraform CDK and Azure AZAPI provider.
+
+## Features
+
+- **Multiple API Version Support**: Supports 2023-09-01 (latest) and 2022-10-01 (for backward compatibility)
+- **Automatic Version Resolution**: Uses the latest API version by default
+- **Version Pinning**: Lock to a specific API version for stability
+- **Type-Safe**: Full TypeScript support with comprehensive interfaces
+- **JSII Compatible**: Can be used from TypeScript, Python, Java, and C#
+- **Terraform Outputs**: Automatic creation of outputs for id, name, workspaceId, and customerId
+- **Tag Management**: Built-in methods for managing resource tags
+
+## Supported API Versions
+
+| Version | Status | Release Date | Notes |
+|---------|--------|--------------|-------|
+| 2023-09-01 | Active (Latest) | 2023-09-01 | Recommended for new deployments, includes Data Collection Rule support |
+| 2022-10-01 | Active | 2022-10-01 | Stable release for backward compatibility |
+
+## Installation
+
+This module is part of the `@microsoft/terraform-cdk-constructs` package.
+
+```bash
+npm install @microsoft/terraform-cdk-constructs
+```
+
+## Basic Usage
+
+### Simple Log Analytics Workspace
+
+```typescript
+import { App, TerraformStack } from "cdktn";
+import { AzapiProvider } from "@microsoft/terraform-cdk-constructs/core-azure";
+import { ResourceGroup } from "@microsoft/terraform-cdk-constructs/azure-resourcegroup";
+import { LogAnalyticsWorkspace } from "@microsoft/terraform-cdk-constructs/azure-loganalyticsworkspace";
+
+const app = new App();
+const stack = new TerraformStack(app, "log-analytics-stack");
+
+// Configure the Azure provider
+new AzapiProvider(stack, "azapi", {});
+
+// Create a resource group
+const resourceGroup = new ResourceGroup(stack, "rg", {
+  name: "my-resource-group",
+  location: "eastus",
+});
+
+// Create a Log Analytics Workspace
+const workspace = new LogAnalyticsWorkspace(stack, "workspace", {
+  name: "my-log-analytics",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  tags: {
+    environment: "production",
+    project: "monitoring",
+  },
+});
+
+app.synth();
+```
+
+## Advanced Usage
+
+### Custom Retention Period
+
+```typescript
+const workspace = new LogAnalyticsWorkspace(stack, "workspace-retention", {
+  name: "workspace-with-retention",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  retentionInDays: 90, // Keep data for 90 days (range: 30-730)
+});
+```
+
+### PerGB2018 Pricing (Pay-as-you-go)
+
+```typescript
+const workspace = new LogAnalyticsWorkspace(stack, "workspace-pergb", {
+  name: "workspace-pergb",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  sku: {
+    name: "PerGB2018",
+  },
+  retentionInDays: 60,
+});
+```
+
+### Capacity Reservation Pricing
+
+```typescript
+const workspace = new LogAnalyticsWorkspace(stack, "workspace-capacity", {
+  name: "workspace-capacity-reservation",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  sku: {
+    name: "CapacityReservation",
+    capacityReservationLevel: 500, // Valid values: 100, 200, 300, 400, 500, 1000, 2000, 5000
+  },
+  retentionInDays: 365,
+});
+```
+
+### Daily Volume Cap (Workspace Capping)
+
+```typescript
+const workspace = new LogAnalyticsWorkspace(stack, "workspace-capped", {
+  name: "workspace-with-cap",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  workspaceCapping: {
+    dailyQuotaGb: 100, // Stop ingestion after 100GB per day
+  },
+});
+```
+
+### Private Network Access
+
+```typescript
+const workspace = new LogAnalyticsWorkspace(stack, "workspace-private", {
+  name: "workspace-private",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  publicNetworkAccessForIngestion: "Disabled",
+  publicNetworkAccessForQuery: "Disabled",
+});
+```
+
+### Workspace Features
+
+```typescript
+const workspace = new LogAnalyticsWorkspace(stack, "workspace-features", {
+  name: "workspace-with-features",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  features: {
+    enableDataExport: true,
+    immediatePurgeDataOn30Days: false,
+    disableLocalAuth: true,
+    enableLogAccessUsingOnlyResourcePermissions: true,
+  },
+});
+```
+
+### Managed Identity
+
+```typescript
+const workspace = new LogAnalyticsWorkspace(stack, "workspace-identity", {
+  name: "workspace-with-identity",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  identity: {
+    type: "SystemAssigned",
+  },
+});
+```
+
+### Pinning to a Specific API Version
+
+```typescript
+const workspace = new LogAnalyticsWorkspace(stack, "workspace-pinned", {
+  name: "workspace-stable",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  apiVersion: "2022-10-01", // Pin to specific version
+});
+```
+
+### Using Outputs
+
+```typescript
+const workspace = new LogAnalyticsWorkspace(stack, "workspace", {
+  name: "my-workspace",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+});
+
+// Access workspace ID for use in other resources (e.g., Diagnostic Settings)
+console.log(workspace.id); // Terraform interpolation string
+
+// Use outputs for cross-stack references
+new TerraformOutput(stack, "workspace-id", {
+  value: workspace.idOutput,
+});
+
+new TerraformOutput(stack, "workspace-customer-id", {
+  value: workspace.customerIdOutput,
+});
+```
+
+## API Reference
+
+### LogAnalyticsWorkspaceProps
+
+Configuration properties for the Log Analytics Workspace construct.
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `name` | `string` | No* | Name of the workspace. If not provided, uses the construct ID. Must be 4-63 characters, alphanumeric and hyphens. |
+| `location` | `string` | Yes | Azure region where the workspace will be created. |
+| `resourceGroupId` | `string` | Yes | Resource group ID where the workspace will be created. |
+| `retentionInDays` | `number` | No | Data retention in days (30-730). Default: 30. |
+| `sku` | `LogAnalyticsWorkspaceSku` | No | SKU configuration. Default: { name: "PerGB2018" }. |
+| `workspaceCapping` | `LogAnalyticsWorkspaceCapping` | No | Daily volume cap configuration. |
+| `publicNetworkAccessForIngestion` | `"Enabled" \| "Disabled"` | No | Network access for data ingestion. Default: "Enabled". |
+| `publicNetworkAccessForQuery` | `"Enabled" \| "Disabled"` | No | Network access for queries. Default: "Enabled". |
+| `features` | `LogAnalyticsWorkspaceFeatures` | No | Workspace feature flags. |
+| `forceCmkForQuery` | `boolean` | No | Require customer-managed keys for saved searches/alerts. |
+| `defaultDataCollectionRuleResourceId` | `string` | No | Default DCR resource ID (API 2023-09-01+). |
+| `identity` | `LogAnalyticsWorkspaceIdentity` | No | Managed identity configuration. |
+| `tags` | `{ [key: string]: string }` | No | Resource tags. |
+| `apiVersion` | `string` | No | Pin to a specific API version. |
+
+### LogAnalyticsWorkspaceSku
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `name` | `string` | Yes | SKU name: "Free", "Standard", "Premium", "PerNode", "PerGB2018", "Standalone", "CapacityReservation" |
+| `capacityReservationLevel` | `number` | No | Capacity in GB/day for CapacityReservation SKU. Valid: 100, 200, 300, 400, 500, 1000, 2000, 5000. |
+
+### LogAnalyticsWorkspaceCapping
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `dailyQuotaGb` | `number` | Yes | Daily volume cap in GB. Use -1 for no cap. |
+
+### LogAnalyticsWorkspaceFeatures
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `enableDataExport` | `boolean` | No | Enable data export capability. |
+| `immediatePurgeDataOn30Days` | `boolean` | No | Purge data immediately after 30 days. |
+| `disableLocalAuth` | `boolean` | No | Disable local authentication. |
+| `enableLogAccessUsingOnlyResourcePermissions` | `boolean` | No | Enable resource-based access only. |
+
+### LogAnalyticsWorkspaceIdentity
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `type` | `string` | Yes | Identity type: "SystemAssigned", "UserAssigned", "SystemAssigned,UserAssigned", "None" |
+| `userAssignedIdentities` | `object` | No | User-assigned identity resource IDs. |
+
+### Public Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `string` | The Azure resource ID of the workspace. |
+| `props` | `LogAnalyticsWorkspaceProps` | The original input properties. |
+| `resolvedApiVersion` | `string` | The API version being used. |
+
+### Outputs
+
+The construct automatically creates Terraform outputs:
+
+- `id`: The workspace resource ID
+- `name`: The workspace name
+- `workspace_id`: The workspace unique identifier (GUID)
+- `customer_id`: The workspace customer ID (same as workspace_id)
+
+### Methods
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| `addTag` | `key: string, value: string` | Add a tag to the workspace. |
+| `addAccess` | `objectId: string, roleDefinitionName: string` | Add RBAC role assignment. |
+
+## Best Practices
+
+### 1. Use PerGB2018 for Most Workloads
+
+Unless you have specific requirements, the pay-as-you-go model is most cost-effective:
+
+```typescript
+const workspace = new LogAnalyticsWorkspace(stack, "workspace", {
+  name: "my-workspace",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  sku: { name: "PerGB2018" },
+});
+```
+
+### 2. Set Appropriate Retention
+
+Balance between compliance requirements and cost:
+
+```typescript
+// Production: longer retention for compliance
+const prodWorkspace = new LogAnalyticsWorkspace(stack, "prod-workspace", {
+  name: "prod-logs",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  retentionInDays: 365,
+});
+
+// Development: shorter retention to save costs
+const devWorkspace = new LogAnalyticsWorkspace(stack, "dev-workspace", {
+  name: "dev-logs", 
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  retentionInDays: 30,
+});
+```
+
+### 3. Use Daily Cap for Cost Control
+
+Prevent unexpected charges from log spikes:
+
+```typescript
+const workspace = new LogAnalyticsWorkspace(stack, "workspace", {
+  name: "cost-controlled",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  workspaceCapping: {
+    dailyQuotaGb: 50, // Stop at 50GB/day
+  },
+});
+```
+
+### 4. Apply Consistent Tags
+
+```typescript
+const workspace = new LogAnalyticsWorkspace(stack, "workspace", {
+  name: "my-workspace",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  tags: {
+    environment: "production",
+    "cost-center": "platform-team",
+    "managed-by": "terraform",
+  },
+});
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Retention Out of Range**: Ensure `retentionInDays` is between 30 and 730.
+
+2. **Invalid Capacity Reservation Level**: Valid values are 100, 200, 300, 400, 500, 1000, 2000, 5000.
+
+3. **Name Validation**: Workspace names must be 4-63 characters, start and end with alphanumeric, and contain only letters, numbers, and hyphens.
+
+4. **API Version Errors**: Ensure the version is 2023-09-01 or 2022-10-01.
+
+## Related Constructs
+
+- [`ResourceGroup`](../azure-resourcegroup/README.md) - Azure Resource Groups
+- [`DiagnosticSettings`](../azure-diagnosticsettings/README.md) - Send logs to this workspace
+- [`MetricAlert`](../azure-metricalert/README.md) - Create alerts based on workspace metrics
+
+## Additional Resources
+
+- [Azure Log Analytics Documentation](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overview)
+- [Log Analytics Pricing](https://azure.microsoft.com/en-us/pricing/details/monitor/)
+- [Azure REST API Reference](https://learn.microsoft.com/en-us/rest/api/loganalytics/)
+- [Terraform CDK Documentation](https://developer.hashicorp.com/terraform/cdktf)
+
+## Contributing
+
+Contributions are welcome! Please see the [Contributing Guide](../../CONTRIBUTING.md) for details.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](../../LICENSE) file for details.

--- a/src/azure-loganalyticsworkspace/index.ts
+++ b/src/azure-loganalyticsworkspace/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Azure Log Analytics Workspace module
+ *
+ * This module provides constructs for creating and managing Azure Log Analytics Workspaces.
+ */
+
+export * from "./lib";

--- a/src/azure-loganalyticsworkspace/lib/index.ts
+++ b/src/azure-loganalyticsworkspace/lib/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Azure Log Analytics Workspace construct exports
+ */
+
+export * from "./log-analytics-workspace-schemas";
+export * from "./log-analytics-workspace";

--- a/src/azure-loganalyticsworkspace/lib/log-analytics-workspace-schemas.ts
+++ b/src/azure-loganalyticsworkspace/lib/log-analytics-workspace-schemas.ts
@@ -1,0 +1,282 @@
+/**
+ * API schemas for Azure Log Analytics Workspace across all supported versions
+ *
+ * This file defines the complete API schemas for Microsoft.OperationalInsights/workspaces
+ * across all supported API versions. The schemas are used by the AzapiResource
+ * framework for validation, transformation, and version management.
+ */
+
+import {
+  ApiSchema,
+  PropertyDefinition,
+  PropertyType,
+  ValidationRuleType,
+  VersionConfig,
+  VersionSupportLevel,
+} from "../../core-azure/lib/version-manager/interfaces/version-interfaces";
+
+// =============================================================================
+// COMMON PROPERTY DEFINITIONS
+// =============================================================================
+
+/**
+ * Common property definitions shared across all Log Analytics Workspace versions
+ */
+const COMMON_LOG_ANALYTICS_WORKSPACE_PROPERTIES: {
+  [key: string]: PropertyDefinition;
+} = {
+  name: {
+    dataType: PropertyType.STRING,
+    required: true,
+    description: "Name of the Log Analytics workspace",
+    validation: [
+      {
+        ruleType: ValidationRuleType.REQUIRED,
+        message: "Name is required",
+      },
+      {
+        ruleType: ValidationRuleType.PATTERN_MATCH,
+        value: "^[a-zA-Z0-9][a-zA-Z0-9-]{2,61}[a-zA-Z0-9]$",
+        message:
+          "Workspace name must be 4-63 characters, start and end with a letter or number, and contain only letters, numbers, and hyphens",
+      },
+    ],
+  },
+  location: {
+    dataType: PropertyType.STRING,
+    required: true,
+    description: "Azure region where the workspace will be created",
+  },
+  retentionInDays: {
+    dataType: PropertyType.NUMBER,
+    required: false,
+    defaultValue: 30,
+    description:
+      "Data retention in days. Values between 30 and 730 are allowed. Default is 30 days.",
+    validation: [
+      {
+        ruleType: ValidationRuleType.VALUE_RANGE,
+        value: { min: 30, max: 730 },
+        message: "Retention must be between 30 and 730 days",
+      },
+    ],
+  },
+  sku: {
+    dataType: PropertyType.OBJECT,
+    required: false,
+    description:
+      "SKU configuration for the workspace. Options: Free, Standard, Premium, PerNode, PerGB2018, Standalone, CapacityReservation",
+  },
+  workspaceCapping: {
+    dataType: PropertyType.OBJECT,
+    required: false,
+    description: "Daily volume cap for data ingestion in GB",
+  },
+  publicNetworkAccessForIngestion: {
+    dataType: PropertyType.STRING,
+    required: false,
+    description:
+      "Public network access for data ingestion: Enabled or Disabled",
+  },
+  publicNetworkAccessForQuery: {
+    dataType: PropertyType.STRING,
+    required: false,
+    description: "Public network access for queries: Enabled or Disabled",
+  },
+  features: {
+    dataType: PropertyType.OBJECT,
+    required: false,
+    description:
+      "Workspace features like enableDataExport, immediatePurgeDataOn30Days, etc.",
+  },
+  forceCmkForQuery: {
+    dataType: PropertyType.BOOLEAN,
+    required: false,
+    description:
+      "Whether customer-managed keys are required for saved searches and alerts",
+  },
+  defaultDataCollectionRuleResourceId: {
+    dataType: PropertyType.STRING,
+    required: false,
+    description: "Resource ID of the default Data Collection Rule",
+    addedInVersion: "2023-09-01",
+  },
+  identity: {
+    dataType: PropertyType.OBJECT,
+    required: false,
+    description: "Managed identity configuration for the workspace",
+  },
+};
+
+// =============================================================================
+// VERSION-SPECIFIC SCHEMAS
+// =============================================================================
+
+/**
+ * API Schema for Log Analytics Workspace version 2023-09-01
+ *
+ * This is the latest stable version for Log Analytics Workspace.
+ * It includes support for:
+ * - Data retention configuration
+ * - SKU management (Free, PerGB2018, CapacityReservation, etc.)
+ * - Daily volume cap (workspace capping)
+ * - Public network access controls
+ * - Workspace features (enableDataExport, immediatePurgeDataOn30Days, etc.)
+ * - Default Data Collection Rule
+ * - Managed identity
+ */
+export const LOG_ANALYTICS_WORKSPACE_SCHEMA_2023_09_01: ApiSchema = {
+  resourceType: "Microsoft.OperationalInsights/workspaces",
+  version: "2023-09-01",
+  properties: {
+    ...COMMON_LOG_ANALYTICS_WORKSPACE_PROPERTIES,
+  },
+  required: ["name", "location"],
+  optional: [
+    "retentionInDays",
+    "sku",
+    "workspaceCapping",
+    "publicNetworkAccessForIngestion",
+    "publicNetworkAccessForQuery",
+    "features",
+    "forceCmkForQuery",
+    "defaultDataCollectionRuleResourceId",
+    "identity",
+  ],
+  deprecated: [],
+  transformationRules: {},
+  validationRules: [
+    {
+      property: "name",
+      rules: [
+        {
+          ruleType: ValidationRuleType.REQUIRED,
+          message: "Name is required for Log Analytics Workspace",
+        },
+      ],
+    },
+  ],
+};
+
+/**
+ * API Schema for Log Analytics Workspace version 2022-10-01
+ *
+ * This is a stable version for backward compatibility.
+ * It includes support for:
+ * - Data retention configuration
+ * - SKU management
+ * - Daily volume cap
+ * - Public network access controls
+ * - Workspace features
+ */
+export const LOG_ANALYTICS_WORKSPACE_SCHEMA_2022_10_01: ApiSchema = {
+  resourceType: "Microsoft.OperationalInsights/workspaces",
+  version: "2022-10-01",
+  properties: {
+    name: COMMON_LOG_ANALYTICS_WORKSPACE_PROPERTIES.name,
+    location: COMMON_LOG_ANALYTICS_WORKSPACE_PROPERTIES.location,
+    retentionInDays: COMMON_LOG_ANALYTICS_WORKSPACE_PROPERTIES.retentionInDays,
+    sku: COMMON_LOG_ANALYTICS_WORKSPACE_PROPERTIES.sku,
+    workspaceCapping:
+      COMMON_LOG_ANALYTICS_WORKSPACE_PROPERTIES.workspaceCapping,
+    publicNetworkAccessForIngestion:
+      COMMON_LOG_ANALYTICS_WORKSPACE_PROPERTIES.publicNetworkAccessForIngestion,
+    publicNetworkAccessForQuery:
+      COMMON_LOG_ANALYTICS_WORKSPACE_PROPERTIES.publicNetworkAccessForQuery,
+    features: COMMON_LOG_ANALYTICS_WORKSPACE_PROPERTIES.features,
+    forceCmkForQuery:
+      COMMON_LOG_ANALYTICS_WORKSPACE_PROPERTIES.forceCmkForQuery,
+    identity: COMMON_LOG_ANALYTICS_WORKSPACE_PROPERTIES.identity,
+    // Note: defaultDataCollectionRuleResourceId is not available in this version
+  },
+  required: ["name", "location"],
+  optional: [
+    "retentionInDays",
+    "sku",
+    "workspaceCapping",
+    "publicNetworkAccessForIngestion",
+    "publicNetworkAccessForQuery",
+    "features",
+    "forceCmkForQuery",
+    "identity",
+  ],
+  deprecated: [],
+  transformationRules: {},
+  validationRules: [
+    {
+      property: "name",
+      rules: [
+        {
+          ruleType: ValidationRuleType.REQUIRED,
+          message: "Name is required for Log Analytics Workspace",
+        },
+      ],
+    },
+  ],
+};
+
+// =============================================================================
+// VERSION CONFIGURATIONS
+// =============================================================================
+
+/**
+ * Version configuration for Log Analytics Workspace 2023-09-01
+ */
+export const LOG_ANALYTICS_WORKSPACE_VERSION_2023_09_01: VersionConfig = {
+  version: "2023-09-01",
+  schema: LOG_ANALYTICS_WORKSPACE_SCHEMA_2023_09_01,
+  supportLevel: VersionSupportLevel.ACTIVE,
+  releaseDate: "2023-09-01",
+  deprecationDate: undefined,
+  sunsetDate: undefined,
+  breakingChanges: [],
+  migrationGuide: "/docs/log-analytics-workspace/migration-2023-09-01",
+  changeLog: [
+    {
+      changeType: "added",
+      description: "Added support for default Data Collection Rule resource ID",
+      breaking: false,
+    },
+    {
+      changeType: "updated",
+      description: "Latest stable API version with enhanced feature support",
+      breaking: false,
+    },
+  ],
+};
+
+/**
+ * Version configuration for Log Analytics Workspace 2022-10-01
+ */
+export const LOG_ANALYTICS_WORKSPACE_VERSION_2022_10_01: VersionConfig = {
+  version: "2022-10-01",
+  schema: LOG_ANALYTICS_WORKSPACE_SCHEMA_2022_10_01,
+  supportLevel: VersionSupportLevel.ACTIVE,
+  releaseDate: "2022-10-01",
+  deprecationDate: undefined,
+  sunsetDate: undefined,
+  breakingChanges: [],
+  migrationGuide: "/docs/log-analytics-workspace/migration-2022-10-01",
+  changeLog: [
+    {
+      changeType: "updated",
+      description: "Stable API version for backward compatibility",
+      breaking: false,
+    },
+  ],
+};
+
+/**
+ * All supported Log Analytics Workspace versions for registration
+ * Ordered with latest stable version first
+ */
+export const ALL_LOG_ANALYTICS_WORKSPACE_VERSIONS: VersionConfig[] = [
+  LOG_ANALYTICS_WORKSPACE_VERSION_2023_09_01,
+  LOG_ANALYTICS_WORKSPACE_VERSION_2022_10_01,
+];
+
+/**
+ * Resource type constant
+ */
+export const LOG_ANALYTICS_WORKSPACE_TYPE =
+  "Microsoft.OperationalInsights/workspaces";

--- a/src/azure-loganalyticsworkspace/lib/log-analytics-workspace.ts
+++ b/src/azure-loganalyticsworkspace/lib/log-analytics-workspace.ts
@@ -1,0 +1,461 @@
+/**
+ * Unified Azure Log Analytics Workspace implementation using AzapiResource framework
+ *
+ * This class provides a version-aware implementation for Azure Log Analytics Workspace
+ * that automatically handles version management, schema validation, and property
+ * transformation across all supported API versions.
+ *
+ * Supported API Versions:
+ * - 2023-09-01 (Active, Latest)
+ * - 2022-10-01 (Active, Backward Compatibility)
+ *
+ * Features:
+ * - Automatic latest version resolution when no version is specified
+ * - Explicit version pinning for stability requirements
+ * - Schema-driven validation and transformation
+ * - Full JSII compliance for multi-language support
+ * - Configurable data retention, SKU, and workspace capping
+ * - Public network access controls
+ * - Workspace features configuration
+ */
+
+import * as cdktf from "cdktn";
+import { Construct } from "constructs";
+import {
+  ALL_LOG_ANALYTICS_WORKSPACE_VERSIONS,
+  LOG_ANALYTICS_WORKSPACE_TYPE,
+} from "./log-analytics-workspace-schemas";
+import {
+  AzapiResource,
+  AzapiResourceProps,
+} from "../../core-azure/lib/azapi/azapi-resource";
+import { ApiSchema } from "../../core-azure/lib/version-manager/interfaces/version-interfaces";
+
+/**
+ * SKU configuration for Log Analytics Workspace
+ */
+export interface LogAnalyticsWorkspaceSku {
+  /**
+   * SKU name for the Log Analytics Workspace
+   *
+   * Available options:
+   * - "Free" - Free tier (limited to 500MB/day, 7 day retention)
+   * - "Standard" - Standard tier (legacy)
+   * - "Premium" - Premium tier (legacy)
+   * - "PerNode" - Per node pricing (legacy, for OMS customers)
+   * - "PerGB2018" - Pay-as-you-go pricing based on data ingestion
+   * - "Standalone" - Standalone tier (legacy)
+   * - "CapacityReservation" - Commitment tier with reserved capacity
+   *
+   * @defaultValue "PerGB2018"
+   */
+  readonly name:
+    | "Free"
+    | "Standard"
+    | "Premium"
+    | "PerNode"
+    | "PerGB2018"
+    | "Standalone"
+    | "CapacityReservation";
+
+  /**
+   * Capacity reservation level in GB per day
+   * Only applicable when SKU name is "CapacityReservation"
+   * Valid values: 100, 200, 300, 400, 500, 1000, 2000, 5000
+   */
+  readonly capacityReservationLevel?: number;
+}
+
+/**
+ * Workspace capping configuration for daily data ingestion limits
+ */
+export interface LogAnalyticsWorkspaceCapping {
+  /**
+   * Daily volume cap in GB
+   * A value of -1 means no cap
+   */
+  readonly dailyQuotaGb: number;
+}
+
+/**
+ * Workspace features configuration
+ */
+export interface LogAnalyticsWorkspaceFeatures {
+  /**
+   * Flag indicating whether data export is enabled
+   */
+  readonly enableDataExport?: boolean;
+
+  /**
+   * Flag indicating whether data should be immediately purged after 30 days
+   * instead of the configured retention period
+   */
+  readonly immediatePurgeDataOn30Days?: boolean;
+
+  /**
+   * Flag indicating whether log access using AADIAM is disabled
+   */
+  readonly disableLocalAuth?: boolean;
+
+  /**
+   * Flag indicating whether cluster resource permissions are enabled
+   */
+  readonly enableLogAccessUsingOnlyResourcePermissions?: boolean;
+}
+
+/**
+ * Managed identity configuration for the workspace
+ */
+export interface LogAnalyticsWorkspaceIdentity {
+  /**
+   * Type of managed identity
+   */
+  readonly type:
+    | "SystemAssigned"
+    | "UserAssigned"
+    | "SystemAssigned,UserAssigned"
+    | "None";
+
+  /**
+   * User-assigned identity resource IDs
+   * Required when type includes UserAssigned
+   */
+  readonly userAssignedIdentities?: { [key: string]: any };
+}
+
+/**
+ * Properties for the unified Azure Log Analytics Workspace
+ *
+ * Extends AzapiResourceProps with Log Analytics Workspace specific properties
+ */
+export interface LogAnalyticsWorkspaceProps extends AzapiResourceProps {
+  /**
+   * Resource Group ID where the workspace will be created
+   * The workspace will be created as a child of this resource group
+   */
+  readonly resourceGroupId: string;
+
+  /**
+   * Data retention period in days
+   *
+   * Values between 30 and 730 are supported for pay-as-you-go pricing.
+   * Free tier is limited to 7 days.
+   *
+   * @defaultValue 30
+   */
+  readonly retentionInDays?: number;
+
+  /**
+   * SKU configuration for the workspace
+   *
+   * Determines pricing tier and capabilities of the workspace.
+   *
+   * @defaultValue { name: "PerGB2018" }
+   */
+  readonly sku?: LogAnalyticsWorkspaceSku;
+
+  /**
+   * Daily volume cap for data ingestion
+   *
+   * When the daily cap is reached, data ingestion stops until the next day.
+   * A value of dailyQuotaGb: -1 means no cap.
+   */
+  readonly workspaceCapping?: LogAnalyticsWorkspaceCapping;
+
+  /**
+   * Public network access for data ingestion
+   *
+   * Controls whether data can be ingested over the public internet.
+   *
+   * @defaultValue "Enabled"
+   */
+  readonly publicNetworkAccessForIngestion?: "Enabled" | "Disabled";
+
+  /**
+   * Public network access for querying data
+   *
+   * Controls whether queries can be executed over the public internet.
+   *
+   * @defaultValue "Enabled"
+   */
+  readonly publicNetworkAccessForQuery?: "Enabled" | "Disabled";
+
+  /**
+   * Workspace features configuration
+   *
+   * Enables or disables specific workspace features like data export,
+   * immediate purge, and local authentication.
+   */
+  readonly features?: LogAnalyticsWorkspaceFeatures;
+
+  /**
+   * Whether customer-managed keys are required for saved searches and alerts
+   *
+   * When enabled, all saved searches and alerts must use customer-managed keys.
+   */
+  readonly forceCmkForQuery?: boolean;
+
+  /**
+   * Resource ID of the default Data Collection Rule
+   *
+   * Associates a default DCR with the workspace for data collection.
+   * Only available in API version 2023-09-01 and later.
+   */
+  readonly defaultDataCollectionRuleResourceId?: string;
+
+  /**
+   * Managed identity configuration for the workspace
+   *
+   * Enables managed identity authentication for the workspace.
+   */
+  readonly identity?: LogAnalyticsWorkspaceIdentity;
+}
+
+/**
+ * Properties for the Log Analytics Workspace request body
+ */
+export interface LogAnalyticsWorkspaceBodyProperties {
+  readonly retentionInDays?: number;
+  readonly sku?: LogAnalyticsWorkspaceSku;
+  readonly workspaceCapping?: LogAnalyticsWorkspaceCapping;
+  readonly publicNetworkAccessForIngestion?: string;
+  readonly publicNetworkAccessForQuery?: string;
+  readonly features?: LogAnalyticsWorkspaceFeatures;
+  readonly forceCmkForQuery?: boolean;
+  readonly defaultDataCollectionRuleResourceId?: string;
+}
+
+/**
+ * The resource body interface for Azure Log Analytics Workspace API calls
+ */
+export interface LogAnalyticsWorkspaceBody {
+  readonly properties: LogAnalyticsWorkspaceBodyProperties;
+  readonly identity?: LogAnalyticsWorkspaceIdentity;
+}
+
+/**
+ * Unified Azure Log Analytics Workspace implementation
+ *
+ * This class provides a single, version-aware implementation that automatically handles version
+ * resolution, schema validation, and property transformation while maintaining full JSII compliance.
+ *
+ * Log Analytics Workspace is the central destination for log data from Azure resources,
+ * applications, and on-premises infrastructure. It enables querying, analysis, and
+ * visualization of log data using Kusto Query Language (KQL).
+ *
+ * @example
+ * // Basic Log Analytics Workspace with default settings:
+ * const workspace = new LogAnalyticsWorkspace(this, "my-workspace", {
+ *   name: "my-log-analytics",
+ *   location: "eastus",
+ *   resourceGroupId: resourceGroup.id,
+ * });
+ *
+ * @example
+ * // Log Analytics Workspace with custom retention and SKU:
+ * const workspace = new LogAnalyticsWorkspace(this, "production-workspace", {
+ *   name: "production-logs",
+ *   location: "eastus",
+ *   resourceGroupId: resourceGroup.id,
+ *   retentionInDays: 90,
+ *   sku: {
+ *     name: "PerGB2018"
+ *   },
+ *   publicNetworkAccessForIngestion: "Enabled",
+ *   publicNetworkAccessForQuery: "Enabled",
+ *   tags: {
+ *     environment: "production"
+ *   }
+ * });
+ *
+ * @example
+ * // Log Analytics Workspace with capacity reservation:
+ * const workspace = new LogAnalyticsWorkspace(this, "high-volume-workspace", {
+ *   name: "high-volume-logs",
+ *   location: "eastus",
+ *   resourceGroupId: resourceGroup.id,
+ *   retentionInDays: 365,
+ *   sku: {
+ *     name: "CapacityReservation",
+ *     capacityReservationLevel: 500
+ *   },
+ *   workspaceCapping: {
+ *     dailyQuotaGb: 100
+ *   }
+ * });
+ *
+ * @stability stable
+ */
+export class LogAnalyticsWorkspace extends AzapiResource {
+  static {
+    AzapiResource.registerSchemas(
+      LOG_ANALYTICS_WORKSPACE_TYPE,
+      ALL_LOG_ANALYTICS_WORKSPACE_VERSIONS,
+    );
+  }
+
+  /**
+   * The input properties for this Log Analytics Workspace instance
+   */
+  public readonly props: LogAnalyticsWorkspaceProps;
+
+  // Output properties for easy access and referencing
+  public readonly idOutput: cdktf.TerraformOutput;
+  public readonly nameOutput: cdktf.TerraformOutput;
+  public readonly workspaceIdOutput: cdktf.TerraformOutput;
+  public readonly customerIdOutput: cdktf.TerraformOutput;
+
+  /**
+   * Creates a new Azure Log Analytics Workspace using the AzapiResource framework
+   *
+   * The constructor automatically handles version resolution, schema registration,
+   * validation, and resource creation.
+   *
+   * @param scope - The scope in which to define this construct
+   * @param id - The unique identifier for this instance
+   * @param props - Configuration properties for the Log Analytics Workspace
+   */
+  constructor(scope: Construct, id: string, props: LogAnalyticsWorkspaceProps) {
+    // Validate retention days if provided
+    if (props.retentionInDays !== undefined) {
+      if (props.retentionInDays < 30 || props.retentionInDays > 730) {
+        throw new Error("retentionInDays must be between 30 and 730 days");
+      }
+    }
+
+    // Validate capacity reservation level if CapacityReservation SKU is used
+    if (props.sku?.name === "CapacityReservation") {
+      const validLevels = [100, 200, 300, 400, 500, 1000, 2000, 5000];
+      if (
+        props.sku.capacityReservationLevel === undefined ||
+        !validLevels.includes(props.sku.capacityReservationLevel)
+      ) {
+        throw new Error(
+          `capacityReservationLevel must be one of ${validLevels.join(", ")} when using CapacityReservation SKU`,
+        );
+      }
+    }
+
+    super(scope, id, props);
+
+    this.props = props;
+
+    // Create Terraform outputs for easy access and referencing from other resources
+    this.idOutput = new cdktf.TerraformOutput(this, "id", {
+      value: this.id,
+      description: "The ID of the Log Analytics Workspace",
+    });
+
+    this.nameOutput = new cdktf.TerraformOutput(this, "name", {
+      value: `\${${this.terraformResource.fqn}.name}`,
+      description: "The name of the Log Analytics Workspace",
+    });
+
+    this.workspaceIdOutput = new cdktf.TerraformOutput(this, "workspace_id", {
+      value: `\${${this.terraformResource.fqn}.output.properties.customerId}`,
+      description:
+        "The unique identifier (workspace ID) of the Log Analytics Workspace",
+    });
+
+    this.customerIdOutput = new cdktf.TerraformOutput(this, "customer_id", {
+      value: `\${${this.terraformResource.fqn}.output.properties.customerId}`,
+      description:
+        "The customer ID (same as workspace ID) of the Log Analytics Workspace",
+    });
+
+    // Override logical IDs
+    this.idOutput.overrideLogicalId("id");
+    this.nameOutput.overrideLogicalId("name");
+    this.workspaceIdOutput.overrideLogicalId("workspace_id");
+    this.customerIdOutput.overrideLogicalId("customer_id");
+  }
+
+  // =============================================================================
+  // REQUIRED ABSTRACT METHODS FROM AzapiResource
+  // =============================================================================
+
+  /**
+   * Gets the default API version to use when no explicit version is specified
+   * Returns the latest stable version as the default
+   */
+  protected defaultVersion(): string {
+    return "2023-09-01";
+  }
+
+  /**
+   * Gets the Azure resource type for Log Analytics Workspace
+   */
+  protected resourceType(): string {
+    return LOG_ANALYTICS_WORKSPACE_TYPE;
+  }
+
+  /**
+   * Gets the API schema for the resolved version
+   * Uses the framework's schema resolution to get the appropriate schema
+   */
+  protected apiSchema(): ApiSchema {
+    return this.resolveSchema();
+  }
+
+  /**
+   * Indicates that this resource type requires a location
+   */
+  protected requiresLocation(): boolean {
+    return true;
+  }
+
+  /**
+   * Creates the resource body for the Azure API call
+   * Transforms the input properties into the JSON format expected by Azure REST API
+   */
+  protected createResourceBody(props: any): any {
+    const typedProps = props as LogAnalyticsWorkspaceProps;
+
+    const body: any = {
+      properties: {
+        retentionInDays: typedProps.retentionInDays ?? 30,
+        sku: typedProps.sku ?? { name: "PerGB2018" },
+        publicNetworkAccessForIngestion:
+          typedProps.publicNetworkAccessForIngestion ?? "Enabled",
+        publicNetworkAccessForQuery:
+          typedProps.publicNetworkAccessForQuery ?? "Enabled",
+      },
+    };
+
+    // Add optional properties only if specified
+    if (typedProps.workspaceCapping) {
+      body.properties.workspaceCapping = typedProps.workspaceCapping;
+    }
+
+    if (typedProps.features) {
+      body.properties.features = typedProps.features;
+    }
+
+    if (typedProps.forceCmkForQuery !== undefined) {
+      body.properties.forceCmkForQuery = typedProps.forceCmkForQuery;
+    }
+
+    if (typedProps.defaultDataCollectionRuleResourceId) {
+      body.properties.defaultDataCollectionRuleResourceId =
+        typedProps.defaultDataCollectionRuleResourceId;
+    }
+
+    // Add identity at the top level if specified
+    if (typedProps.identity) {
+      body.identity = typedProps.identity;
+    }
+
+    return body;
+  }
+
+  /**
+   * Resolves the parent resource ID for Log Analytics Workspace
+   * Log Analytics Workspace is a top-level resource within a resource group
+   *
+   * @param props - The resource properties
+   * @returns The parent resource ID (the resource group)
+   */
+  protected resolveParentId(props: any): string {
+    return (props as LogAnalyticsWorkspaceProps).resourceGroupId;
+  }
+}

--- a/src/azure-loganalyticsworkspace/test/log-analytics-workspace.integ.ts
+++ b/src/azure-loganalyticsworkspace/test/log-analytics-workspace.integ.ts
@@ -1,0 +1,80 @@
+/**
+ * Integration test for Azure Log Analytics Workspace
+ *
+ * This test demonstrates basic usage of the LogAnalyticsWorkspace construct
+ * and validates deployment, idempotency, and cleanup.
+ *
+ * Run with: npm run integration:nostream
+ */
+
+import { Testing, TerraformStack } from "cdktn";
+import { Construct } from "constructs";
+import "cdktn/lib/testing/adapters/jest";
+import { ResourceGroup } from "../../azure-resourcegroup";
+import { AzapiProvider } from "../../core-azure/lib/azapi/providers-azapi/provider";
+import { TerraformApplyCheckAndDestroy } from "../../testing";
+import { LogAnalyticsWorkspace } from "../lib/log-analytics-workspace";
+
+/**
+ * Example stack demonstrating Log Analytics Workspace usage
+ */
+class LogAnalyticsWorkspaceExampleStack extends TerraformStack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    // Configure AZAPI provider
+    new AzapiProvider(this, "azapi", {});
+
+    // Create a resource group
+    const resourceGroup = new ResourceGroup(this, "example-rg", {
+      name: "law-example-rg",
+      location: "eastus",
+      tags: {
+        environment: "example",
+        purpose: "integration-test",
+      },
+    });
+
+    // Example 1: Basic Log Analytics Workspace
+    new LogAnalyticsWorkspace(this, "basic-workspace", {
+      name: "law-basic-example",
+      location: resourceGroup.props.location!,
+      resourceGroupId: resourceGroup.id,
+      tags: {
+        example: "basic",
+      },
+    });
+
+    // Example 2: Log Analytics Workspace with specific version
+    new LogAnalyticsWorkspace(this, "versioned-workspace", {
+      name: "law-versioned-example",
+      location: resourceGroup.props.location!,
+      resourceGroupId: resourceGroup.id,
+      retentionInDays: 60,
+      sku: {
+        name: "PerGB2018",
+      },
+      apiVersion: "2023-09-01",
+      tags: {
+        example: "versioned",
+      },
+    });
+  }
+}
+
+describe("Log Analytics Workspace Integration Test", () => {
+  it("should deploy, validate idempotency, and cleanup Log Analytics Workspace resources", () => {
+    const app = Testing.app();
+    const stack = new LogAnalyticsWorkspaceExampleStack(
+      app,
+      "test-log-analytics-workspace",
+    );
+    const synthesized = Testing.fullSynth(stack);
+
+    // This will:
+    // 1. Run terraform apply to deploy resources
+    // 2. Run terraform plan to check idempotency (no changes expected)
+    // 3. Run terraform destroy to cleanup resources
+    TerraformApplyCheckAndDestroy(synthesized);
+  }, 600000); // 10 minute timeout for deployment and cleanup
+});

--- a/src/azure-loganalyticsworkspace/test/log-analytics-workspace.spec.ts
+++ b/src/azure-loganalyticsworkspace/test/log-analytics-workspace.spec.ts
@@ -1,0 +1,653 @@
+/**
+ * Comprehensive tests for the LogAnalyticsWorkspace implementation
+ *
+ * This test suite validates the LogAnalyticsWorkspace class using the AzapiResource framework.
+ * Tests cover automatic version resolution, explicit version pinning, schema validation,
+ * property configurations, and resource creation.
+ */
+
+import { Testing } from "cdktn";
+import * as cdktf from "cdktn";
+import {
+  LogAnalyticsWorkspace,
+  LogAnalyticsWorkspaceProps,
+} from "../lib/log-analytics-workspace";
+
+describe("LogAnalyticsWorkspace - Implementation", () => {
+  let app: cdktf.App;
+  let stack: cdktf.TerraformStack;
+
+  beforeEach(() => {
+    app = Testing.app();
+    stack = new cdktf.TerraformStack(app, "TestStack");
+  });
+
+  // =============================================================================
+  // Constructor and Basic Properties
+  // =============================================================================
+
+  describe("Constructor and Basic Properties", () => {
+    it("should create a Log Analytics Workspace with minimal configuration", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "test-workspace",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      };
+
+      const workspace = new LogAnalyticsWorkspace(
+        stack,
+        "TestWorkspace",
+        props,
+      );
+
+      expect(workspace).toBeInstanceOf(LogAnalyticsWorkspace);
+      expect(workspace.props).toBe(props);
+      expect(workspace.props.name).toBe("test-workspace");
+      expect(workspace.props.location).toBe("eastus");
+    });
+
+    it("should create a Log Analytics Workspace with custom retention", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "retention-workspace",
+        location: "westus2",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        retentionInDays: 90,
+      };
+
+      const workspace = new LogAnalyticsWorkspace(
+        stack,
+        "RetentionWorkspace",
+        props,
+      );
+
+      expect(workspace.props.retentionInDays).toBe(90);
+    });
+
+    it("should create a Log Analytics Workspace with PerGB2018 SKU", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "sku-workspace",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        sku: {
+          name: "PerGB2018",
+        },
+      };
+
+      const workspace = new LogAnalyticsWorkspace(stack, "SkuWorkspace", props);
+
+      expect(workspace.props.sku?.name).toBe("PerGB2018");
+    });
+
+    it("should create a Log Analytics Workspace with CapacityReservation SKU", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "capacity-workspace",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        sku: {
+          name: "CapacityReservation",
+          capacityReservationLevel: 500,
+        },
+      };
+
+      const workspace = new LogAnalyticsWorkspace(
+        stack,
+        "CapacityWorkspace",
+        props,
+      );
+
+      expect(workspace.props.sku?.name).toBe("CapacityReservation");
+      expect(workspace.props.sku?.capacityReservationLevel).toBe(500);
+    });
+
+    it("should create a Log Analytics Workspace with workspace capping", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "capped-workspace",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        workspaceCapping: {
+          dailyQuotaGb: 100,
+        },
+      };
+
+      const workspace = new LogAnalyticsWorkspace(
+        stack,
+        "CappedWorkspace",
+        props,
+      );
+
+      expect(workspace.props.workspaceCapping?.dailyQuotaGb).toBe(100);
+    });
+  });
+
+  // =============================================================================
+  // Version Resolution
+  // =============================================================================
+
+  describe("Version Resolution", () => {
+    it("should use latest version 2023-09-01 when no version specified", () => {
+      const workspace = new LogAnalyticsWorkspace(stack, "DefaultVersion", {
+        name: "default-version-workspace",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      });
+
+      expect(workspace.resolvedApiVersion).toBe("2023-09-01");
+    });
+
+    it("should use explicit version when specified", () => {
+      const workspace = new LogAnalyticsWorkspace(stack, "PinnedVersion", {
+        name: "pinned-version-workspace",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        apiVersion: "2022-10-01",
+      });
+
+      expect(workspace.resolvedApiVersion).toBe("2022-10-01");
+    });
+
+    it("should use latest version 2023-09-01 when explicitly specified", () => {
+      const workspace = new LogAnalyticsWorkspace(stack, "LatestVersion", {
+        name: "latest-version-workspace",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        apiVersion: "2023-09-01",
+      });
+
+      expect(workspace.resolvedApiVersion).toBe("2023-09-01");
+    });
+  });
+
+  // =============================================================================
+  // Validation Tests
+  // =============================================================================
+
+  describe("Validation", () => {
+    it("should throw error when retention is below minimum", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "invalid-retention",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        retentionInDays: 7,
+      };
+
+      expect(() => {
+        new LogAnalyticsWorkspace(stack, "InvalidRetention", props);
+      }).toThrow(/retentionInDays must be between 30 and 730/);
+    });
+
+    it("should throw error when retention is above maximum", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "invalid-retention",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        retentionInDays: 1000,
+      };
+
+      expect(() => {
+        new LogAnalyticsWorkspace(stack, "InvalidRetentionMax", props);
+      }).toThrow(/retentionInDays must be between 30 and 730/);
+    });
+
+    it("should throw error when CapacityReservation SKU has invalid level", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "invalid-capacity",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        sku: {
+          name: "CapacityReservation",
+          capacityReservationLevel: 50, // Invalid level
+        },
+      };
+
+      expect(() => {
+        new LogAnalyticsWorkspace(stack, "InvalidCapacity", props);
+      }).toThrow(/capacityReservationLevel must be one of/);
+    });
+
+    it("should throw error when CapacityReservation SKU has no level", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "missing-capacity-level",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        sku: {
+          name: "CapacityReservation",
+        },
+      };
+
+      expect(() => {
+        new LogAnalyticsWorkspace(stack, "MissingCapacityLevel", props);
+      }).toThrow(/capacityReservationLevel must be one of/);
+    });
+
+    it("should accept valid retention values", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "valid-retention",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        retentionInDays: 365,
+      };
+
+      expect(() => {
+        new LogAnalyticsWorkspace(stack, "ValidRetention", props);
+      }).not.toThrow();
+    });
+
+    it("should accept valid CapacityReservation levels", () => {
+      const validLevels = [100, 200, 300, 400, 500, 1000, 2000, 5000];
+
+      validLevels.forEach((level, index) => {
+        const props: LogAnalyticsWorkspaceProps = {
+          name: `valid-capacity-${level}`,
+          location: "eastus",
+          resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+          sku: {
+            name: "CapacityReservation",
+            capacityReservationLevel: level,
+          },
+        };
+
+        expect(() => {
+          new LogAnalyticsWorkspace(stack, `ValidCapacity${index}`, props);
+        }).not.toThrow();
+      });
+    });
+  });
+
+  // =============================================================================
+  // Public Network Access Configuration
+  // =============================================================================
+
+  describe("Public Network Access Configuration", () => {
+    it("should configure public network access for ingestion", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "network-ingestion",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        publicNetworkAccessForIngestion: "Disabled",
+      };
+
+      const workspace = new LogAnalyticsWorkspace(
+        stack,
+        "NetworkIngestion",
+        props,
+      );
+
+      expect(workspace.props.publicNetworkAccessForIngestion).toBe("Disabled");
+    });
+
+    it("should configure public network access for query", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "network-query",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        publicNetworkAccessForQuery: "Disabled",
+      };
+
+      const workspace = new LogAnalyticsWorkspace(stack, "NetworkQuery", props);
+
+      expect(workspace.props.publicNetworkAccessForQuery).toBe("Disabled");
+    });
+
+    it("should configure both public network access settings", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "network-both",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        publicNetworkAccessForIngestion: "Disabled",
+        publicNetworkAccessForQuery: "Disabled",
+      };
+
+      const workspace = new LogAnalyticsWorkspace(stack, "NetworkBoth", props);
+
+      expect(workspace.props.publicNetworkAccessForIngestion).toBe("Disabled");
+      expect(workspace.props.publicNetworkAccessForQuery).toBe("Disabled");
+    });
+  });
+
+  // =============================================================================
+  // Workspace Features Configuration
+  // =============================================================================
+
+  describe("Workspace Features Configuration", () => {
+    it("should configure enableDataExport feature", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "feature-export",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        features: {
+          enableDataExport: true,
+        },
+      };
+
+      const workspace = new LogAnalyticsWorkspace(
+        stack,
+        "FeatureExport",
+        props,
+      );
+
+      expect(workspace.props.features?.enableDataExport).toBe(true);
+    });
+
+    it("should configure immediatePurgeDataOn30Days feature", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "feature-purge",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        features: {
+          immediatePurgeDataOn30Days: true,
+        },
+      };
+
+      const workspace = new LogAnalyticsWorkspace(stack, "FeaturePurge", props);
+
+      expect(workspace.props.features?.immediatePurgeDataOn30Days).toBe(true);
+    });
+
+    it("should configure disableLocalAuth feature", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "feature-auth",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        features: {
+          disableLocalAuth: true,
+        },
+      };
+
+      const workspace = new LogAnalyticsWorkspace(stack, "FeatureAuth", props);
+
+      expect(workspace.props.features?.disableLocalAuth).toBe(true);
+    });
+
+    it("should configure multiple features", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "feature-multi",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        features: {
+          enableDataExport: true,
+          immediatePurgeDataOn30Days: false,
+          disableLocalAuth: true,
+          enableLogAccessUsingOnlyResourcePermissions: true,
+        },
+      };
+
+      const workspace = new LogAnalyticsWorkspace(stack, "FeatureMulti", props);
+
+      expect(workspace.props.features?.enableDataExport).toBe(true);
+      expect(workspace.props.features?.immediatePurgeDataOn30Days).toBe(false);
+      expect(workspace.props.features?.disableLocalAuth).toBe(true);
+      expect(
+        workspace.props.features?.enableLogAccessUsingOnlyResourcePermissions,
+      ).toBe(true);
+    });
+  });
+
+  // =============================================================================
+  // Property Transformation
+  // =============================================================================
+
+  describe("Property Transformation", () => {
+    it("should generate correct Azure API format via createResourceBody", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "transform-test",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        retentionInDays: 60,
+        sku: {
+          name: "PerGB2018",
+        },
+      };
+
+      const workspace = new LogAnalyticsWorkspace(
+        stack,
+        "TransformTest",
+        props,
+      );
+
+      // Access the protected createResourceBody method
+      const resourceBody = (workspace as any).createResourceBody(props);
+
+      expect(resourceBody).toHaveProperty("properties");
+      expect(resourceBody.properties).toHaveProperty("retentionInDays", 60);
+      expect(resourceBody.properties).toHaveProperty("sku");
+      expect(resourceBody.properties.sku.name).toBe("PerGB2018");
+    });
+
+    it("should include workspaceCapping when specified", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "capping-test",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        workspaceCapping: {
+          dailyQuotaGb: 50,
+        },
+      };
+
+      const workspace = new LogAnalyticsWorkspace(stack, "CappingTest", props);
+      const resourceBody = (workspace as any).createResourceBody(props);
+
+      expect(resourceBody.properties.workspaceCapping).toBeDefined();
+      expect(resourceBody.properties.workspaceCapping.dailyQuotaGb).toBe(50);
+    });
+
+    it("should include identity when specified", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "identity-test",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        identity: {
+          type: "SystemAssigned",
+        },
+      };
+
+      const workspace = new LogAnalyticsWorkspace(stack, "IdentityTest", props);
+      const resourceBody = (workspace as any).createResourceBody(props);
+
+      expect(resourceBody.identity).toBeDefined();
+      expect(resourceBody.identity.type).toBe("SystemAssigned");
+    });
+
+    it("should apply default values for retention and SKU", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "defaults-test",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      };
+
+      const workspace = new LogAnalyticsWorkspace(stack, "DefaultsTest", props);
+      const resourceBody = (workspace as any).createResourceBody(props);
+
+      expect(resourceBody.properties.retentionInDays).toBe(30);
+      expect(resourceBody.properties.sku.name).toBe("PerGB2018");
+      expect(resourceBody.properties.publicNetworkAccessForIngestion).toBe(
+        "Enabled",
+      );
+      expect(resourceBody.properties.publicNetworkAccessForQuery).toBe(
+        "Enabled",
+      );
+    });
+  });
+
+  // =============================================================================
+  // Integration with Base Class
+  // =============================================================================
+
+  describe("Integration with Base Class", () => {
+    it("should inherit from AzapiResource", () => {
+      const workspace = new LogAnalyticsWorkspace(stack, "InheritanceTest", {
+        name: "inheritance-test",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      });
+
+      // Verify it has AzapiResource properties
+      expect(workspace).toHaveProperty("terraformResource");
+      expect(workspace).toHaveProperty("resolvedApiVersion");
+    });
+
+    it("should have correct resourceType", () => {
+      const workspace = new LogAnalyticsWorkspace(stack, "ResourceTypeTest", {
+        name: "resource-type-test",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      });
+
+      // Access the protected resourceType method
+      const resourceType = (workspace as any).resourceType();
+      expect(resourceType).toBe("Microsoft.OperationalInsights/workspaces");
+    });
+
+    it("should resolve parent ID correctly", () => {
+      const resourceGroupId = "/subscriptions/test-sub/resourceGroups/test-rg";
+
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "parent-id-test",
+        location: "eastus",
+        resourceGroupId,
+      };
+
+      const workspace = new LogAnalyticsWorkspace(stack, "ParentIdTest", props);
+
+      // Access the protected resolveParentId method
+      const parentId = (workspace as any).resolveParentId(props);
+      expect(parentId).toBe(resourceGroupId);
+    });
+
+    it("should generate resource outputs", () => {
+      const workspace = new LogAnalyticsWorkspace(stack, "OutputsTest", {
+        name: "outputs-test",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      });
+
+      expect(workspace.idOutput).toBeInstanceOf(cdktf.TerraformOutput);
+      expect(workspace.nameOutput).toBeInstanceOf(cdktf.TerraformOutput);
+      expect(workspace.workspaceIdOutput).toBeInstanceOf(cdktf.TerraformOutput);
+      expect(workspace.customerIdOutput).toBeInstanceOf(cdktf.TerraformOutput);
+      expect(workspace.id).toMatch(/^\$\{.*\.id\}$/);
+    });
+  });
+
+  // =============================================================================
+  // CDK Terraform Integration
+  // =============================================================================
+
+  describe("CDK Terraform Integration", () => {
+    it("should synthesize to valid Terraform configuration", () => {
+      new LogAnalyticsWorkspace(stack, "SynthTest", {
+        name: "synth-test",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        retentionInDays: 90,
+        sku: {
+          name: "PerGB2018",
+        },
+      });
+
+      const synthesized = Testing.synth(stack);
+      expect(synthesized).toBeDefined();
+
+      const stackConfig = JSON.parse(synthesized);
+      expect(stackConfig.resource).toBeDefined();
+    });
+
+    it("should handle multiple workspaces in the same stack", () => {
+      const workspace1 = new LogAnalyticsWorkspace(stack, "Workspace1", {
+        name: "workspace-1",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      });
+
+      const workspace2 = new LogAnalyticsWorkspace(stack, "Workspace2", {
+        name: "workspace-2",
+        location: "westus2",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        apiVersion: "2022-10-01",
+      });
+
+      expect(workspace1.resolvedApiVersion).toBe("2023-09-01");
+      expect(workspace2.resolvedApiVersion).toBe("2022-10-01");
+
+      const synthesized = Testing.synth(stack);
+      expect(synthesized).toBeDefined();
+    });
+  });
+
+  // =============================================================================
+  // Complex Scenarios
+  // =============================================================================
+
+  describe("Complex Scenarios", () => {
+    it("should handle comprehensive workspace configuration", () => {
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "comprehensive-workspace",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        retentionInDays: 365,
+        sku: {
+          name: "CapacityReservation",
+          capacityReservationLevel: 1000,
+        },
+        workspaceCapping: {
+          dailyQuotaGb: 200,
+        },
+        publicNetworkAccessForIngestion: "Enabled",
+        publicNetworkAccessForQuery: "Disabled",
+        features: {
+          enableDataExport: true,
+          immediatePurgeDataOn30Days: false,
+          disableLocalAuth: true,
+        },
+        forceCmkForQuery: true,
+        identity: {
+          type: "SystemAssigned",
+        },
+        tags: {
+          environment: "production",
+          team: "platform",
+        },
+      };
+
+      const workspace = new LogAnalyticsWorkspace(
+        stack,
+        "ComprehensiveConfig",
+        props,
+      );
+      const resourceBody = (workspace as any).createResourceBody(props);
+
+      expect(resourceBody.properties.retentionInDays).toBe(365);
+      expect(resourceBody.properties.sku.name).toBe("CapacityReservation");
+      expect(resourceBody.properties.sku.capacityReservationLevel).toBe(1000);
+      expect(resourceBody.properties.workspaceCapping.dailyQuotaGb).toBe(200);
+      expect(resourceBody.properties.publicNetworkAccessForIngestion).toBe(
+        "Enabled",
+      );
+      expect(resourceBody.properties.publicNetworkAccessForQuery).toBe(
+        "Disabled",
+      );
+      expect(resourceBody.properties.features.enableDataExport).toBe(true);
+      expect(resourceBody.properties.features.disableLocalAuth).toBe(true);
+      expect(resourceBody.properties.forceCmkForQuery).toBe(true);
+      expect(resourceBody.identity.type).toBe("SystemAssigned");
+    });
+
+    it("should handle workspace with defaultDataCollectionRuleResourceId", () => {
+      const dcrId =
+        "/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Insights/dataCollectionRules/test-dcr";
+
+      const props: LogAnalyticsWorkspaceProps = {
+        name: "dcr-workspace",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        defaultDataCollectionRuleResourceId: dcrId,
+      };
+
+      const workspace = new LogAnalyticsWorkspace(stack, "DcrWorkspace", props);
+      const resourceBody = (workspace as any).createResourceBody(props);
+
+      expect(resourceBody.properties.defaultDataCollectionRuleResourceId).toBe(
+        dcrId,
+      );
+    });
+  });
+});

--- a/src/azure-networkwatcher/README.md
+++ b/src/azure-networkwatcher/README.md
@@ -1,0 +1,270 @@
+# Azure Network Watcher Construct
+
+This module provides a high-level TypeScript construct for managing Azure Network Watchers using the Terraform CDK and Azure AZAPI provider.
+
+## Features
+
+- **Multiple API Version Support**: Supports 2024-01-01 (latest) and 2023-11-01 (for backward compatibility)
+- **Automatic Version Resolution**: Uses the latest API version by default
+- **Version Pinning**: Lock to a specific API version for stability
+- **Type-Safe**: Full TypeScript support with comprehensive interfaces
+- **JSII Compatible**: Can be used from TypeScript, Python, Java, and C#
+- **Terraform Outputs**: Automatic creation of outputs for id, name, location, and provisioningState
+- **Tag Management**: Built-in methods for managing resource tags
+
+## Important Note: One Per Region Limitation
+
+⚠️ **Azure only allows one Network Watcher per subscription per region.** 
+
+If you attempt to create a Network Watcher in a region where one already exists, the deployment will fail. This is an Azure platform limitation, not a construct limitation.
+
+Azure automatically creates Network Watchers in a resource group named `NetworkWatcherRG` when certain network features are used. Before creating a Network Watcher, check if one already exists in your target region.
+
+## Supported API Versions
+
+| Version | Status | Release Date | Notes |
+|---------|--------|--------------|-------|
+| 2024-01-01 | Active (Latest) | 2024-01-01 | Recommended for new deployments |
+| 2023-11-01 | Active | 2023-11-01 | Stable release for backward compatibility |
+
+## Installation
+
+This module is part of the `@microsoft/terraform-cdk-constructs` package.
+
+```bash
+npm install @microsoft/terraform-cdk-constructs
+```
+
+## Basic Usage
+
+### Simple Network Watcher
+
+```typescript
+import { App, TerraformStack } from "cdktn";
+import { AzapiProvider } from "@microsoft/terraform-cdk-constructs/core-azure";
+import { ResourceGroup } from "@microsoft/terraform-cdk-constructs/azure-resourcegroup";
+import { NetworkWatcher } from "@microsoft/terraform-cdk-constructs/azure-networkwatcher";
+
+const app = new App();
+const stack = new TerraformStack(app, "network-watcher-stack");
+
+// Configure the Azure provider
+new AzapiProvider(stack, "azapi", {});
+
+// Create a resource group
+const resourceGroup = new ResourceGroup(stack, "rg", {
+  name: "my-resource-group",
+  location: "eastus",
+});
+
+// Create a Network Watcher
+const networkWatcher = new NetworkWatcher(stack, "network-watcher", {
+  name: "my-network-watcher",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  tags: {
+    environment: "production",
+  },
+});
+
+app.synth();
+```
+
+### Using Azure's Default Naming Convention
+
+Azure typically uses a naming convention of `NetworkWatcher_<region>` for auto-provisioned Network Watchers:
+
+```typescript
+const networkWatcher = new NetworkWatcher(stack, "network-watcher", {
+  name: "NetworkWatcher_eastus",
+  location: "eastus",
+  resourceGroupId: networkWatcherRg.id,
+});
+```
+
+### Pinning to a Specific API Version
+
+```typescript
+const networkWatcher = new NetworkWatcher(stack, "network-watcher", {
+  name: "my-network-watcher",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  apiVersion: "2023-11-01", // Pin to specific version
+});
+```
+
+## Using Network Watcher with Flow Logs
+
+Network Watcher is primarily used as a dependency for other Network Watcher features. Here's an example of how you might use it with NSG Flow Logs (once the Flow Log construct is available):
+
+```typescript
+// Create the Network Watcher
+const networkWatcher = new NetworkWatcher(stack, "network-watcher", {
+  name: "NetworkWatcher_eastus",
+  location: "eastus",
+  resourceGroupId: networkWatcherRg.id,
+});
+
+// Use the Network Watcher ID with Flow Logs or other features
+// (Flow Log construct example - coming soon)
+// const flowLog = new NsgFlowLog(stack, "flow-log", {
+//   networkWatcherId: networkWatcher.id,
+//   networkSecurityGroupId: nsg.id,
+//   storageAccountId: storageAccount.id,
+// });
+```
+
+## Network Watcher Features
+
+Network Watcher serves as the anchor for various network monitoring and diagnostic features:
+
+| Feature | Description |
+|---------|-------------|
+| **NSG Flow Logs** | Capture information about IP traffic flowing through NSGs |
+| **Connection Monitor** | Monitor reachability, latency, and network topology changes |
+| **Packet Capture** | Capture packets to/from virtual machines |
+| **IP Flow Verify** | Check if a packet is allowed or denied to/from a VM |
+| **Next Hop** | Get the next hop from a VM |
+| **VPN Troubleshoot** | Diagnose Azure VPN Gateway and connections |
+| **Network Topology** | View network resources and their relationships |
+| **Security Group View** | View NSGs and rules applied to a VM |
+
+## API Reference
+
+### NetworkWatcherProps
+
+Configuration properties for the Network Watcher construct.
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `name` | `string` | No* | Name of the Network Watcher. If not provided, uses the construct ID. |
+| `location` | `string` | Yes | Azure region where the Network Watcher will be created. Only one per region per subscription. |
+| `resourceGroupId` | `string` | Yes | Resource group ID where the Network Watcher will be created. |
+| `tags` | `{ [key: string]: string }` | No | Resource tags. |
+| `apiVersion` | `string` | No | Pin to a specific API version. |
+
+### Public Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `string` | The Azure resource ID of the Network Watcher. |
+| `props` | `NetworkWatcherProps` | The original input properties. |
+| `resolvedApiVersion` | `string` | The API version being used. |
+
+### Outputs
+
+The construct automatically creates Terraform outputs:
+
+- `id`: The Network Watcher resource ID
+- `name`: The Network Watcher name
+- `location`: The Network Watcher location (region)
+- `provisioning_state`: The provisioning state of the Network Watcher
+
+### Methods
+
+| Method | Parameters | Description |
+|--------|-----------|-------------|
+| `addTag` | `key: string, value: string` | Add a tag to the Network Watcher. |
+| `addAccess` | `objectId: string, roleDefinitionName: string` | Add RBAC role assignment. |
+
+## Best Practices
+
+### 1. Use a Dedicated Resource Group
+
+Consider using a dedicated resource group for Network Watchers, similar to Azure's convention:
+
+```typescript
+const networkWatcherRg = new ResourceGroup(stack, "network-watcher-rg", {
+  name: "NetworkWatcherRG",
+  location: "eastus",
+});
+
+const networkWatcher = new NetworkWatcher(stack, "network-watcher", {
+  name: "NetworkWatcher_eastus",
+  location: "eastus",
+  resourceGroupId: networkWatcherRg.id,
+});
+```
+
+### 2. Check for Existing Network Watchers
+
+Before creating a Network Watcher, verify that one doesn't already exist in the target region:
+
+```bash
+az network watcher list --query "[?location=='eastus']"
+```
+
+### 3. Create Network Watchers for Each Required Region
+
+If you need Network Watcher features in multiple regions, create a Network Watcher for each:
+
+```typescript
+const regions = ["eastus", "westus2", "northeurope"];
+
+regions.forEach(region => {
+  new NetworkWatcher(stack, `network-watcher-${region}`, {
+    name: `NetworkWatcher_${region}`,
+    location: region,
+    resourceGroupId: networkWatcherRg.id,
+  });
+});
+```
+
+### 4. Use Consistent Naming and Tagging
+
+```typescript
+const networkWatcher = new NetworkWatcher(stack, "network-watcher", {
+  name: "NetworkWatcher_eastus",
+  location: "eastus",
+  resourceGroupId: resourceGroup.id,
+  tags: {
+    environment: "production",
+    "managed-by": "terraform-cdk",
+    "created-by": "platform-team",
+  },
+});
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **"A network watcher already exists in the subscription for region"**
+   
+   A Network Watcher already exists in that region. Azure allows only one per region per subscription.
+   
+   Solution: Import the existing Network Watcher or use a different region.
+
+2. **"Resource group not found"**
+   
+   The specified resource group doesn't exist.
+   
+   Solution: Ensure the resource group is created before the Network Watcher, either using a `ResourceGroup` construct or by referencing an existing resource group.
+
+3. **"Location is required"**
+   
+   Network Watcher requires a location to be specified.
+   
+   Solution: Always provide the `location` property.
+
+## Related Constructs
+
+- [`ResourceGroup`](../azure-resourcegroup/README.md) - Azure Resource Groups
+- [`VirtualNetwork`](../azure-virtualnetwork/README.md) - Azure Virtual Networks
+- [`NetworkSecurityGroup`](../azure-networksecuritygroup/README.md) - Network Security Groups
+
+## Additional Resources
+
+- [Azure Network Watcher Documentation](https://learn.microsoft.com/en-us/azure/network-watcher/network-watcher-overview)
+- [Network Watcher REST API Reference](https://learn.microsoft.com/en-us/rest/api/network-watcher/)
+- [NSG Flow Logs Documentation](https://learn.microsoft.com/en-us/azure/network-watcher/nsg-flow-logs-overview)
+- [Connection Monitor Documentation](https://learn.microsoft.com/en-us/azure/network-watcher/connection-monitor-overview)
+- [Terraform CDK Documentation](https://developer.hashicorp.com/terraform/cdktf)
+
+## Contributing
+
+Contributions are welcome! Please see the [Contributing Guide](../../CONTRIBUTING.md) for details.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](../../LICENSE) file for details.

--- a/src/azure-networkwatcher/index.ts
+++ b/src/azure-networkwatcher/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Azure Network Watcher module
+ *
+ * This module provides constructs for creating and managing Azure Network Watchers.
+ *
+ * Network Watcher is a regional service that provides network monitoring and diagnostic
+ * tools in Azure. It enables you to monitor and diagnose conditions at a network scenario
+ * level in, to, and from Azure.
+ *
+ * IMPORTANT: Azure only allows one Network Watcher per subscription per region.
+ * If you need Network Watcher functionality in multiple regions, you must create
+ * a separate Network Watcher for each region.
+ */
+
+export * from "./lib";

--- a/src/azure-networkwatcher/lib/index.ts
+++ b/src/azure-networkwatcher/lib/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Azure Network Watcher construct exports
+ */
+
+export * from "./network-watcher-schemas";
+export * from "./network-watcher";

--- a/src/azure-networkwatcher/lib/network-watcher-schemas.ts
+++ b/src/azure-networkwatcher/lib/network-watcher-schemas.ts
@@ -1,0 +1,185 @@
+/**
+ * API schemas for Azure Network Watcher across all supported versions
+ *
+ * This file defines the complete API schemas for Microsoft.Network/networkWatchers
+ * across all supported API versions. The schemas are used by the AzapiResource
+ * framework for validation, transformation, and version management.
+ *
+ * IMPORTANT: Azure only allows one Network Watcher per subscription per region.
+ * Network Watcher is primarily used as a dependency for other Network Watcher features like:
+ * - Flow Logs
+ * - Connection Monitor
+ * - Packet Capture
+ * - Network Diagnostic Tools
+ */
+
+import {
+  ApiSchema,
+  PropertyDefinition,
+  PropertyType,
+  ValidationRuleType,
+  VersionConfig,
+  VersionSupportLevel,
+} from "../../core-azure/lib/version-manager/interfaces/version-interfaces";
+
+// =============================================================================
+// COMMON PROPERTY DEFINITIONS
+// =============================================================================
+
+/**
+ * Common property definitions shared across all Network Watcher versions
+ *
+ * Network Watcher is a relatively simple resource with minimal properties.
+ * It primarily serves as an anchor for Network Watcher features (Flow Logs,
+ * Connection Monitor, Packet Capture, etc.) in a specific region.
+ */
+const COMMON_NETWORK_WATCHER_PROPERTIES: {
+  [key: string]: PropertyDefinition;
+} = {
+  name: {
+    dataType: PropertyType.STRING,
+    required: true,
+    description: "Name of the Network Watcher",
+    validation: [
+      {
+        ruleType: ValidationRuleType.REQUIRED,
+        message: "Name is required",
+      },
+      {
+        ruleType: ValidationRuleType.PATTERN_MATCH,
+        value: "^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,78}[a-zA-Z0-9_]$",
+        message:
+          "Network Watcher name must be 1-80 characters, start with a letter or number, end with a letter, number, or underscore, and contain only letters, numbers, underscores, periods, and hyphens",
+      },
+    ],
+  },
+  location: {
+    dataType: PropertyType.STRING,
+    required: true,
+    description:
+      "Azure region where the Network Watcher will be created. Note: Only one Network Watcher per region per subscription is allowed.",
+  },
+};
+
+// =============================================================================
+// VERSION-SPECIFIC SCHEMAS
+// =============================================================================
+
+/**
+ * API Schema for Network Watcher version 2024-01-01
+ *
+ * This is the latest stable version for Network Watcher.
+ * Network Watcher is a relatively simple resource - it primarily serves as
+ * an anchor for Network Watcher features in a region.
+ */
+export const NETWORK_WATCHER_SCHEMA_2024_01_01: ApiSchema = {
+  resourceType: "Microsoft.Network/networkWatchers",
+  version: "2024-01-01",
+  properties: {
+    ...COMMON_NETWORK_WATCHER_PROPERTIES,
+  },
+  required: ["name", "location"],
+  optional: [],
+  deprecated: [],
+  transformationRules: {},
+  validationRules: [
+    {
+      property: "name",
+      rules: [
+        {
+          ruleType: ValidationRuleType.REQUIRED,
+          message: "Name is required for Network Watcher",
+        },
+      ],
+    },
+  ],
+};
+
+/**
+ * API Schema for Network Watcher version 2023-11-01
+ *
+ * This is a stable version for backward compatibility.
+ * Network Watcher API is very stable with minimal changes between versions.
+ */
+export const NETWORK_WATCHER_SCHEMA_2023_11_01: ApiSchema = {
+  resourceType: "Microsoft.Network/networkWatchers",
+  version: "2023-11-01",
+  properties: {
+    ...COMMON_NETWORK_WATCHER_PROPERTIES,
+  },
+  required: ["name", "location"],
+  optional: [],
+  deprecated: [],
+  transformationRules: {},
+  validationRules: [
+    {
+      property: "name",
+      rules: [
+        {
+          ruleType: ValidationRuleType.REQUIRED,
+          message: "Name is required for Network Watcher",
+        },
+      ],
+    },
+  ],
+};
+
+// =============================================================================
+// VERSION CONFIGURATIONS
+// =============================================================================
+
+/**
+ * Version configuration for Network Watcher 2024-01-01
+ */
+export const NETWORK_WATCHER_VERSION_2024_01_01: VersionConfig = {
+  version: "2024-01-01",
+  schema: NETWORK_WATCHER_SCHEMA_2024_01_01,
+  supportLevel: VersionSupportLevel.ACTIVE,
+  releaseDate: "2024-01-01",
+  deprecationDate: undefined,
+  sunsetDate: undefined,
+  breakingChanges: [],
+  migrationGuide: "/docs/network-watcher/migration-2024-01-01",
+  changeLog: [
+    {
+      changeType: "updated",
+      description: "Latest stable API version",
+      breaking: false,
+    },
+  ],
+};
+
+/**
+ * Version configuration for Network Watcher 2023-11-01
+ */
+export const NETWORK_WATCHER_VERSION_2023_11_01: VersionConfig = {
+  version: "2023-11-01",
+  schema: NETWORK_WATCHER_SCHEMA_2023_11_01,
+  supportLevel: VersionSupportLevel.ACTIVE,
+  releaseDate: "2023-11-01",
+  deprecationDate: undefined,
+  sunsetDate: undefined,
+  breakingChanges: [],
+  migrationGuide: "/docs/network-watcher/migration-2023-11-01",
+  changeLog: [
+    {
+      changeType: "updated",
+      description: "Stable API version for backward compatibility",
+      breaking: false,
+    },
+  ],
+};
+
+/**
+ * All supported Network Watcher versions for registration
+ * Ordered with latest stable version first
+ */
+export const ALL_NETWORK_WATCHER_VERSIONS: VersionConfig[] = [
+  NETWORK_WATCHER_VERSION_2024_01_01,
+  NETWORK_WATCHER_VERSION_2023_11_01,
+];
+
+/**
+ * Resource type constant
+ */
+export const NETWORK_WATCHER_TYPE = "Microsoft.Network/networkWatchers";

--- a/src/azure-networkwatcher/lib/network-watcher.ts
+++ b/src/azure-networkwatcher/lib/network-watcher.ts
@@ -1,0 +1,266 @@
+/**
+ * Unified Azure Network Watcher implementation using AzapiResource framework
+ *
+ * This class provides a version-aware implementation for Azure Network Watcher
+ * that automatically handles version management, schema validation, and property
+ * transformation across all supported API versions.
+ *
+ * IMPORTANT: Azure only allows one Network Watcher per subscription per region.
+ * If you attempt to create a Network Watcher in a region where one already exists,
+ * the deployment will fail.
+ *
+ * Supported API Versions:
+ * - 2024-01-01 (Active, Latest)
+ * - 2023-11-01 (Active, Backward Compatibility)
+ *
+ * Features:
+ * - Automatic latest version resolution when no version is specified
+ * - Explicit version pinning for stability requirements
+ * - Schema-driven validation and transformation
+ * - Full JSII compliance for multi-language support
+ *
+ * Network Watcher is primarily used as a dependency for other Network Watcher features:
+ * - Flow Logs
+ * - Connection Monitor
+ * - Packet Capture
+ * - Network Diagnostic Tools
+ */
+
+import * as cdktf from "cdktn";
+import { Construct } from "constructs";
+import {
+  ALL_NETWORK_WATCHER_VERSIONS,
+  NETWORK_WATCHER_TYPE,
+} from "./network-watcher-schemas";
+import {
+  AzapiResource,
+  AzapiResourceProps,
+} from "../../core-azure/lib/azapi/azapi-resource";
+import { ApiSchema } from "../../core-azure/lib/version-manager/interfaces/version-interfaces";
+
+/**
+ * Properties for the unified Azure Network Watcher
+ *
+ * Extends AzapiResourceProps with Network Watcher specific properties.
+ *
+ * IMPORTANT: Azure only allows one Network Watcher per subscription per region.
+ * Attempting to create multiple Network Watchers in the same region will fail.
+ */
+export interface NetworkWatcherProps extends AzapiResourceProps {
+  /**
+   * Resource Group ID where the Network Watcher will be created
+   *
+   * The Network Watcher will be created as a child of this resource group.
+   * It's recommended to use a dedicated resource group for Network Watchers,
+   * as Azure automatically creates one named "NetworkWatcherRG" when certain
+   * network features are used.
+   */
+  readonly resourceGroupId: string;
+}
+
+/**
+ * The resource body interface for Azure Network Watcher API calls
+ *
+ * Network Watcher is a simple resource with minimal properties.
+ * The properties block is typically empty.
+ */
+export interface NetworkWatcherBody {
+  readonly properties: { [key: string]: any };
+}
+
+/**
+ * Unified Azure Network Watcher implementation
+ *
+ * This class provides a single, version-aware implementation that automatically handles version
+ * resolution, schema validation, and property transformation while maintaining full JSII compliance.
+ *
+ * Network Watcher is a regional service that provides tools to monitor, diagnose, and gain
+ * insights into your network health and performance in Azure. It serves as the anchor for
+ * Network Watcher features like Flow Logs, Connection Monitor, and Packet Capture.
+ *
+ * IMPORTANT CONSTRAINT: Azure only allows one Network Watcher per subscription per region.
+ * If you need Network Watcher functionality in multiple regions, you must create a separate
+ * Network Watcher for each region.
+ *
+ * @example
+ * // Basic Network Watcher:
+ * const networkWatcher = new NetworkWatcher(this, "network-watcher", {
+ *   name: "nw-eastus",
+ *   location: "eastus",
+ *   resourceGroupId: resourceGroup.id,
+ * });
+ *
+ * @example
+ * // Network Watcher with specific API version:
+ * const networkWatcher = new NetworkWatcher(this, "network-watcher", {
+ *   name: "nw-westus2",
+ *   location: "westus2",
+ *   resourceGroupId: resourceGroup.id,
+ *   apiVersion: "2024-01-01",
+ *   tags: {
+ *     environment: "production",
+ *   },
+ * });
+ *
+ * @example
+ * // Network Watcher for use with Flow Logs:
+ * const networkWatcher = new NetworkWatcher(this, "network-watcher", {
+ *   name: "NetworkWatcher_eastus",
+ *   location: "eastus",
+ *   resourceGroupId: networkWatcherRg.id,
+ * });
+ *
+ * // Then use it with NSG Flow Logs
+ * const flowLog = new NsgFlowLog(this, "flow-log", {
+ *   networkWatcherId: networkWatcher.id,
+ *   // ... other properties
+ * });
+ *
+ * @stability stable
+ */
+export class NetworkWatcher extends AzapiResource {
+  static {
+    AzapiResource.registerSchemas(
+      NETWORK_WATCHER_TYPE,
+      ALL_NETWORK_WATCHER_VERSIONS,
+    );
+  }
+
+  /**
+   * The input properties for this Network Watcher instance
+   */
+  public readonly props: NetworkWatcherProps;
+
+  // Output properties for easy access and referencing
+  /**
+   * Terraform output for the Network Watcher resource ID
+   */
+  public readonly idOutput: cdktf.TerraformOutput;
+
+  /**
+   * Terraform output for the Network Watcher name
+   */
+  public readonly nameOutput: cdktf.TerraformOutput;
+
+  /**
+   * Terraform output for the Network Watcher location
+   */
+  public readonly locationOutput: cdktf.TerraformOutput;
+
+  /**
+   * Terraform output for the Network Watcher provisioning state
+   */
+  public readonly provisioningStateOutput: cdktf.TerraformOutput;
+
+  /**
+   * Creates a new Azure Network Watcher using the AzapiResource framework
+   *
+   * The constructor automatically handles version resolution, schema registration,
+   * validation, and resource creation.
+   *
+   * IMPORTANT: Azure only allows one Network Watcher per subscription per region.
+   * Attempting to create a Network Watcher in a region where one already exists
+   * will result in a deployment error.
+   *
+   * @param scope - The scope in which to define this construct
+   * @param id - The unique identifier for this instance
+   * @param props - Configuration properties for the Network Watcher
+   */
+  constructor(scope: Construct, id: string, props: NetworkWatcherProps) {
+    super(scope, id, props);
+
+    this.props = props;
+
+    // Create Terraform outputs for easy access and referencing from other resources
+    this.idOutput = new cdktf.TerraformOutput(this, "id", {
+      value: this.id,
+      description: "The ID of the Network Watcher",
+    });
+
+    this.nameOutput = new cdktf.TerraformOutput(this, "name", {
+      value: `\${${this.terraformResource.fqn}.name}`,
+      description: "The name of the Network Watcher",
+    });
+
+    this.locationOutput = new cdktf.TerraformOutput(this, "location", {
+      value: `\${${this.terraformResource.fqn}.output.location}`,
+      description: "The location of the Network Watcher",
+    });
+
+    this.provisioningStateOutput = new cdktf.TerraformOutput(
+      this,
+      "provisioning_state",
+      {
+        value: `\${${this.terraformResource.fqn}.output.properties.provisioningState}`,
+        description: "The provisioning state of the Network Watcher",
+      },
+    );
+
+    // Override logical IDs
+    this.idOutput.overrideLogicalId("id");
+    this.nameOutput.overrideLogicalId("name");
+    this.locationOutput.overrideLogicalId("location");
+    this.provisioningStateOutput.overrideLogicalId("provisioning_state");
+  }
+
+  // =============================================================================
+  // REQUIRED ABSTRACT METHODS FROM AzapiResource
+  // =============================================================================
+
+  /**
+   * Gets the default API version to use when no explicit version is specified
+   * Returns the latest stable version as the default
+   */
+  protected defaultVersion(): string {
+    return "2024-01-01";
+  }
+
+  /**
+   * Gets the Azure resource type for Network Watcher
+   */
+  protected resourceType(): string {
+    return NETWORK_WATCHER_TYPE;
+  }
+
+  /**
+   * Gets the API schema for the resolved version
+   * Uses the framework's schema resolution to get the appropriate schema
+   */
+  protected apiSchema(): ApiSchema {
+    return this.resolveSchema();
+  }
+
+  /**
+   * Indicates that this resource type requires a location
+   */
+  protected requiresLocation(): boolean {
+    return true;
+  }
+
+  /**
+   * Creates the resource body for the Azure API call
+   *
+   * Network Watcher is a simple resource with an empty properties block.
+   * All configuration is handled at the resource level (name, location, tags).
+   */
+  protected createResourceBody(_props: any): any {
+    // Network Watcher has an empty properties block
+    // The resource is configured primarily through name, location, and tags
+    const body: any = {
+      properties: {},
+    };
+
+    return body;
+  }
+
+  /**
+   * Resolves the parent resource ID for Network Watcher
+   * Network Watcher is a top-level resource within a resource group
+   *
+   * @param props - The resource properties
+   * @returns The parent resource ID (the resource group)
+   */
+  protected resolveParentId(props: any): string {
+    return (props as NetworkWatcherProps).resourceGroupId;
+  }
+}

--- a/src/azure-networkwatcher/test/network-watcher.integ.ts
+++ b/src/azure-networkwatcher/test/network-watcher.integ.ts
@@ -1,0 +1,90 @@
+/**
+ * Integration test for Azure Network Watcher
+ *
+ * This test demonstrates basic usage of the NetworkWatcher construct
+ * and validates deployment, idempotency, and cleanup.
+ *
+ * IMPORTANT: Azure only allows one Network Watcher per subscription per region.
+ * If a Network Watcher already exists in the test region, this test will fail.
+ *
+ * Run with: npm run integration:nostream
+ */
+
+import { Testing, TerraformStack } from "cdktn";
+import { Construct } from "constructs";
+import "cdktn/lib/testing/adapters/jest";
+import { ResourceGroup } from "../../azure-resourcegroup";
+import { AzapiProvider } from "../../core-azure/lib/azapi/providers-azapi/provider";
+import { TerraformApplyCheckAndDestroy } from "../../testing";
+import { NetworkWatcher } from "../lib/network-watcher";
+
+/**
+ * Example stack demonstrating Network Watcher usage
+ *
+ * Note: This example creates a dedicated resource group for the Network Watcher.
+ * In practice, Azure often uses a resource group named "NetworkWatcherRG" for
+ * automatically provisioned Network Watchers.
+ */
+class NetworkWatcherExampleStack extends TerraformStack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    // Configure AZAPI provider
+    new AzapiProvider(this, "azapi", {});
+
+    // Create a resource group for Network Watcher
+    // Note: Azure typically uses NetworkWatcherRG for auto-provisioned Network Watchers
+    // Using northeurope to avoid conflict with existing Network Watchers
+    const resourceGroup = new ResourceGroup(this, "example-rg", {
+      name: "nw-example-rg",
+      location: "northeurope",
+      tags: {
+        environment: "example",
+        purpose: "integration-test",
+      },
+    });
+
+    // Example 1: Basic Network Watcher
+    // Note: Only one Network Watcher per region per subscription is allowed
+    new NetworkWatcher(this, "basic-network-watcher", {
+      name: "nw-basic-example",
+      location: resourceGroup.props.location!,
+      resourceGroupId: resourceGroup.id,
+      tags: {
+        example: "basic",
+      },
+    });
+
+    // Example 2: Network Watcher with specific version
+    // Using a different construct ID but same region (this is for demonstration only -
+    // in practice, you should only have one Network Watcher per region)
+    // This example shows version pinning but would fail if deployed alongside Example 1
+    // since both use the same region.
+    // Uncomment for testing version pinning in a different region:
+    /*
+    new NetworkWatcher(this, "versioned-network-watcher", {
+      name: "nw-versioned-example",
+      location: "westus2",  // Different region
+      resourceGroupId: resourceGroup.id,
+      apiVersion: "2024-01-01",
+      tags: {
+        example: "versioned",
+      },
+    });
+    */
+  }
+}
+
+describe("Network Watcher Integration Test", () => {
+  it("should deploy, validate idempotency, and cleanup Network Watcher resources", () => {
+    const app = Testing.app();
+    const stack = new NetworkWatcherExampleStack(app, "test-network-watcher");
+    const synthesized = Testing.fullSynth(stack);
+
+    // This will:
+    // 1. Run terraform apply to deploy resources
+    // 2. Run terraform plan to check idempotency (no changes expected)
+    // 3. Run terraform destroy to cleanup resources
+    TerraformApplyCheckAndDestroy(synthesized);
+  }, 600000); // 10 minute timeout for deployment and cleanup
+});

--- a/src/azure-networkwatcher/test/network-watcher.spec.ts
+++ b/src/azure-networkwatcher/test/network-watcher.spec.ts
@@ -1,0 +1,396 @@
+/**
+ * Comprehensive tests for the NetworkWatcher implementation
+ *
+ * This test suite validates the NetworkWatcher class using the AzapiResource framework.
+ * Tests cover automatic version resolution, explicit version pinning, schema validation,
+ * property configurations, and resource creation.
+ */
+
+import { Testing } from "cdktn";
+import * as cdktf from "cdktn";
+import { NetworkWatcher, NetworkWatcherProps } from "../lib/network-watcher";
+
+describe("NetworkWatcher - Implementation", () => {
+  let app: cdktf.App;
+  let stack: cdktf.TerraformStack;
+
+  beforeEach(() => {
+    app = Testing.app();
+    stack = new cdktf.TerraformStack(app, "TestStack");
+  });
+
+  // =============================================================================
+  // Constructor and Basic Properties
+  // =============================================================================
+
+  describe("Constructor and Basic Properties", () => {
+    it("should create a Network Watcher with minimal configuration", () => {
+      const props: NetworkWatcherProps = {
+        name: "test-network-watcher",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      };
+
+      const networkWatcher = new NetworkWatcher(
+        stack,
+        "TestNetworkWatcher",
+        props,
+      );
+
+      expect(networkWatcher).toBeInstanceOf(NetworkWatcher);
+      expect(networkWatcher.props).toBe(props);
+      expect(networkWatcher.props.name).toBe("test-network-watcher");
+      expect(networkWatcher.props.location).toBe("eastus");
+    });
+
+    it("should create a Network Watcher with tags", () => {
+      const props: NetworkWatcherProps = {
+        name: "tagged-network-watcher",
+        location: "westus2",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        tags: {
+          environment: "production",
+          team: "networking",
+        },
+      };
+
+      const networkWatcher = new NetworkWatcher(
+        stack,
+        "TaggedNetworkWatcher",
+        props,
+      );
+
+      expect(networkWatcher.props.tags).toEqual({
+        environment: "production",
+        team: "networking",
+      });
+    });
+
+    it("should create a Network Watcher with conventional naming", () => {
+      const props: NetworkWatcherProps = {
+        name: "NetworkWatcher_eastus",
+        location: "eastus",
+        resourceGroupId:
+          "/subscriptions/test-sub/resourceGroups/NetworkWatcherRG",
+      };
+
+      const networkWatcher = new NetworkWatcher(
+        stack,
+        "ConventionalNetworkWatcher",
+        props,
+      );
+
+      expect(networkWatcher.props.name).toBe("NetworkWatcher_eastus");
+    });
+  });
+
+  // =============================================================================
+  // Version Resolution
+  // =============================================================================
+
+  describe("Version Resolution", () => {
+    it("should use latest version 2024-01-01 when no version specified", () => {
+      const networkWatcher = new NetworkWatcher(stack, "DefaultVersion", {
+        name: "default-version-nw",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      });
+
+      expect(networkWatcher.resolvedApiVersion).toBe("2024-01-01");
+    });
+
+    it("should use explicit version when specified", () => {
+      const networkWatcher = new NetworkWatcher(stack, "PinnedVersion", {
+        name: "pinned-version-nw",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        apiVersion: "2023-11-01",
+      });
+
+      expect(networkWatcher.resolvedApiVersion).toBe("2023-11-01");
+    });
+
+    it("should use latest version 2024-01-01 when explicitly specified", () => {
+      const networkWatcher = new NetworkWatcher(stack, "LatestVersion", {
+        name: "latest-version-nw",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        apiVersion: "2024-01-01",
+      });
+
+      expect(networkWatcher.resolvedApiVersion).toBe("2024-01-01");
+    });
+  });
+
+  // =============================================================================
+  // Property Transformation
+  // =============================================================================
+
+  describe("Property Transformation", () => {
+    it("should generate correct Azure API format via createResourceBody", () => {
+      const props: NetworkWatcherProps = {
+        name: "transform-test",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      };
+
+      const networkWatcher = new NetworkWatcher(stack, "TransformTest", props);
+
+      // Access the protected createResourceBody method
+      const resourceBody = (networkWatcher as any).createResourceBody(props);
+
+      expect(resourceBody).toHaveProperty("properties");
+      expect(resourceBody.properties).toEqual({});
+    });
+
+    it("should have empty properties block for Network Watcher", () => {
+      const props: NetworkWatcherProps = {
+        name: "empty-props-test",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        tags: {
+          test: "value",
+        },
+      };
+
+      const networkWatcher = new NetworkWatcher(stack, "EmptyPropsTest", props);
+      const resourceBody = (networkWatcher as any).createResourceBody(props);
+
+      // Network Watcher properties should be empty - tags are handled at resource level
+      expect(Object.keys(resourceBody.properties).length).toBe(0);
+    });
+  });
+
+  // =============================================================================
+  // Integration with Base Class
+  // =============================================================================
+
+  describe("Integration with Base Class", () => {
+    it("should inherit from AzapiResource", () => {
+      const networkWatcher = new NetworkWatcher(stack, "InheritanceTest", {
+        name: "inheritance-test",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      });
+
+      // Verify it has AzapiResource properties
+      expect(networkWatcher).toHaveProperty("terraformResource");
+      expect(networkWatcher).toHaveProperty("resolvedApiVersion");
+    });
+
+    it("should have correct resourceType", () => {
+      const networkWatcher = new NetworkWatcher(stack, "ResourceTypeTest", {
+        name: "resource-type-test",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      });
+
+      // Access the protected resourceType method
+      const resourceType = (networkWatcher as any).resourceType();
+      expect(resourceType).toBe("Microsoft.Network/networkWatchers");
+    });
+
+    it("should resolve parent ID correctly", () => {
+      const resourceGroupId = "/subscriptions/test-sub/resourceGroups/test-rg";
+
+      const props: NetworkWatcherProps = {
+        name: "parent-id-test",
+        location: "eastus",
+        resourceGroupId,
+      };
+
+      const networkWatcher = new NetworkWatcher(stack, "ParentIdTest", props);
+
+      // Access the protected resolveParentId method
+      const parentId = (networkWatcher as any).resolveParentId(props);
+      expect(parentId).toBe(resourceGroupId);
+    });
+
+    it("should generate resource outputs", () => {
+      const networkWatcher = new NetworkWatcher(stack, "OutputsTest", {
+        name: "outputs-test",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      });
+
+      expect(networkWatcher.idOutput).toBeInstanceOf(cdktf.TerraformOutput);
+      expect(networkWatcher.nameOutput).toBeInstanceOf(cdktf.TerraformOutput);
+      expect(networkWatcher.locationOutput).toBeInstanceOf(
+        cdktf.TerraformOutput,
+      );
+      expect(networkWatcher.provisioningStateOutput).toBeInstanceOf(
+        cdktf.TerraformOutput,
+      );
+      expect(networkWatcher.id).toMatch(/^\$\{.*\.id\}$/);
+    });
+  });
+
+  // =============================================================================
+  // CDK Terraform Integration
+  // =============================================================================
+
+  describe("CDK Terraform Integration", () => {
+    it("should synthesize to valid Terraform configuration", () => {
+      new NetworkWatcher(stack, "SynthTest", {
+        name: "synth-test",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      });
+
+      const synthesized = Testing.synth(stack);
+      expect(synthesized).toBeDefined();
+
+      const stackConfig = JSON.parse(synthesized);
+      expect(stackConfig.resource).toBeDefined();
+    });
+
+    it("should handle multiple Network Watchers in the same stack (different regions)", () => {
+      // Note: In practice, Azure only allows one Network Watcher per region per subscription
+      // but CDK can synthesize multiple in the same stack for different regions
+      const nw1 = new NetworkWatcher(stack, "NetworkWatcher1", {
+        name: "nw-eastus",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      });
+
+      const nw2 = new NetworkWatcher(stack, "NetworkWatcher2", {
+        name: "nw-westus2",
+        location: "westus2",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        apiVersion: "2023-11-01",
+      });
+
+      expect(nw1.resolvedApiVersion).toBe("2024-01-01");
+      expect(nw2.resolvedApiVersion).toBe("2023-11-01");
+      expect(nw1.props.location).toBe("eastus");
+      expect(nw2.props.location).toBe("westus2");
+
+      const synthesized = Testing.synth(stack);
+      expect(synthesized).toBeDefined();
+    });
+  });
+
+  // =============================================================================
+  // Location Requirement
+  // =============================================================================
+
+  describe("Location Requirement", () => {
+    it("should require location for Network Watcher", () => {
+      const networkWatcher = new NetworkWatcher(stack, "LocationTest", {
+        name: "location-test",
+        location: "centralus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      });
+
+      // Access the protected requiresLocation method
+      const requiresLocation = (networkWatcher as any).requiresLocation();
+      expect(requiresLocation).toBe(true);
+    });
+
+    it("should accept various Azure regions", () => {
+      const regions = [
+        "eastus",
+        "westus2",
+        "northeurope",
+        "southeastasia",
+        "brazilsouth",
+      ];
+
+      regions.forEach((region, index) => {
+        const props: NetworkWatcherProps = {
+          name: `nw-${region}`,
+          location: region,
+          resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        };
+
+        expect(() => {
+          new NetworkWatcher(stack, `RegionTest${index}`, props);
+        }).not.toThrow();
+      });
+    });
+  });
+
+  // =============================================================================
+  // Naming Conventions
+  // =============================================================================
+
+  describe("Naming Conventions", () => {
+    it("should accept Azure default Network Watcher naming convention", () => {
+      // Azure typically creates Network Watchers with names like "NetworkWatcher_<region>"
+      const props: NetworkWatcherProps = {
+        name: "NetworkWatcher_eastus",
+        location: "eastus",
+        resourceGroupId:
+          "/subscriptions/test-sub/resourceGroups/NetworkWatcherRG",
+      };
+
+      expect(() => {
+        new NetworkWatcher(stack, "AzureDefaultNaming", props);
+      }).not.toThrow();
+    });
+
+    it("should accept custom naming with hyphens", () => {
+      const props: NetworkWatcherProps = {
+        name: "my-custom-network-watcher",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      };
+
+      expect(() => {
+        new NetworkWatcher(stack, "CustomNaming", props);
+      }).not.toThrow();
+    });
+
+    it("should accept naming with periods", () => {
+      const props: NetworkWatcherProps = {
+        name: "nw.prod.eastus",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+      };
+
+      expect(() => {
+        new NetworkWatcher(stack, "PeriodNaming", props);
+      }).not.toThrow();
+    });
+  });
+
+  // =============================================================================
+  // Complete Example Configuration
+  // =============================================================================
+
+  describe("Complete Example Configuration", () => {
+    it("should handle comprehensive Network Watcher configuration", () => {
+      const props: NetworkWatcherProps = {
+        name: "comprehensive-network-watcher",
+        location: "eastus",
+        resourceGroupId: "/subscriptions/test-sub/resourceGroups/test-rg",
+        apiVersion: "2024-01-01",
+        tags: {
+          environment: "production",
+          team: "platform",
+          "cost-center": "networking",
+          "managed-by": "terraform-cdk",
+        },
+      };
+
+      const networkWatcher = new NetworkWatcher(
+        stack,
+        "ComprehensiveConfig",
+        props,
+      );
+
+      expect(networkWatcher.props.name).toBe("comprehensive-network-watcher");
+      expect(networkWatcher.props.location).toBe("eastus");
+      expect(networkWatcher.resolvedApiVersion).toBe("2024-01-01");
+      expect(networkWatcher.props.tags).toEqual({
+        environment: "production",
+        team: "platform",
+        "cost-center": "networking",
+        "managed-by": "terraform-cdk",
+      });
+
+      const resourceBody = (networkWatcher as any).createResourceBody(props);
+      expect(resourceBody.properties).toEqual({});
+    });
+  });
+});

--- a/src/azure-policysetdefinition/README.md
+++ b/src/azure-policysetdefinition/README.md
@@ -1,0 +1,440 @@
+# Azure Policy Set Definition (Initiative) Construct
+
+This module provides a high-level TypeScript construct for managing Azure Policy Set Definitions (also known as Initiatives) using the Terraform CDK and Azure AZAPI provider.
+
+## Features
+
+- **Multiple API Version Support**: Supports 2023-04-01 (latest) and 2021-06-01 (for backward compatibility)
+- **Automatic Version Resolution**: Uses the latest API version by default
+- **Version Pinning**: Lock to a specific API version for stability
+- **Type-Safe**: Full TypeScript support with comprehensive interfaces
+- **JSII Compatible**: Can be used from TypeScript, Python, Java, and C#
+- **Terraform Outputs**: Automatic creation of outputs for id, name, and policySetDefinitionId
+- **Policy Definition References**: Support for including multiple policy definitions
+- **Policy Definition Groups**: Organize policies within initiatives
+- **Initiative Parameters**: Define parameters that can be used across policies in the set
+- **Metadata Support**: Categorization with category, version, preview, and deprecated flags
+
+## What is a Policy Set Definition (Initiative)?
+
+A Policy Set Definition, also known as an "Initiative" in the Azure Portal, is a collection of policy definitions that are grouped together toward a specific goal. Initiatives simplify managing and assigning policies by grouping a set of policies as one single item.
+
+**Key Benefits:**
+- **Simplified Assignment**: Assign multiple policies at once
+- **Compliance Grouping**: Group related compliance controls together
+- **Parameter Inheritance**: Pass parameters to multiple policies from a single assignment
+- **Organized Management**: Use groups to categorize policies within an initiative
+
+## Supported API Versions
+
+| Version | Status | Release Date | Notes |
+|---------|--------|--------------|-------|
+| 2023-04-01 | Active (Latest) | 2023-04-01 | Recommended for new deployments |
+| 2021-06-01 | Active | 2021-06-01 | Stable release for backward compatibility |
+
+## Installation
+
+This module is part of the `@microsoft/terraform-cdk-constructs` package.
+
+```bash
+npm install @microsoft/terraform-cdk-constructs
+```
+
+## Basic Usage
+
+### Simple Initiative with Built-in Policies
+
+```typescript
+import { App, TerraformStack } from "cdktn";
+import { AzapiProvider } from "@microsoft/terraform-cdk-constructs/core-azure";
+import { PolicySetDefinition } from "@microsoft/terraform-cdk-constructs/azure-policysetdefinition";
+
+const app = new App();
+const stack = new TerraformStack(app, "policy-stack");
+
+// Configure the Azure provider
+new AzapiProvider(stack, "azapi", {});
+
+// Create a Policy Set Definition (Initiative)
+const initiative = new PolicySetDefinition(stack, "security-initiative", {
+  displayName: "Security Baseline Initiative",
+  description: "Applies security baseline policies to ensure compliance",
+  scope: "/subscriptions/00000000-0000-0000-0000-000000000000",
+  policyDefinitions: [
+    {
+      // Audit VMs that do not use managed disks
+      policyDefinitionId: "/providers/Microsoft.Authorization/policyDefinitions/06a78e20-9358-41c9-923c-fb736d382a4d",
+      policyDefinitionReferenceId: "auditManagedDisks",
+    },
+    {
+      // Audit location of resources
+      policyDefinitionId: "/providers/Microsoft.Authorization/policyDefinitions/e56962a6-4747-49cd-b67b-bf8b01975c4c",
+      policyDefinitionReferenceId: "allowedLocations",
+    },
+  ],
+  tags: {
+    environment: "production",
+    compliance: "required",
+  },
+});
+
+app.synth();
+```
+
+## Advanced Usage
+
+### Initiative with Parameters
+
+```typescript
+const initiative = new PolicySetDefinition(stack, "parameterized-initiative", {
+  displayName: "Tagging Governance Initiative",
+  description: "Ensures all resources have required tags",
+  scope: "/subscriptions/00000000-0000-0000-0000-000000000000",
+  parameters: {
+    requiredTagName: {
+      type: "String",
+      displayName: "Required Tag Name",
+      description: "Name of the tag that must be present on resources",
+      defaultValue: "costCenter",
+    },
+    requiredTagValue: {
+      type: "String",
+      displayName: "Required Tag Value",
+      description: "Expected value for the required tag",
+    },
+  },
+  policyDefinitions: [
+    {
+      policyDefinitionId: "/providers/Microsoft.Authorization/policyDefinitions/1e30110a-5ceb-460c-a204-c1c3969c6d62",
+      policyDefinitionReferenceId: "requireTagOnResourceGroup",
+      parameters: {
+        tagName: { value: "[parameters('requiredTagName')]" },
+      },
+    },
+    {
+      policyDefinitionId: "/providers/Microsoft.Authorization/policyDefinitions/726aca4c-86e9-4b04-b0c5-073027359532",
+      policyDefinitionReferenceId: "inheritTagFromResourceGroup",
+      parameters: {
+        tagName: { value: "[parameters('requiredTagName')]" },
+      },
+    },
+  ],
+});
+```
+
+### Initiative with Policy Groups
+
+```typescript
+const initiative = new PolicySetDefinition(stack, "grouped-initiative", {
+  displayName: "Comprehensive Compliance Initiative",
+  description: "Security and compliance policies organized by category",
+  scope: "/subscriptions/00000000-0000-0000-0000-000000000000",
+  metadata: {
+    category: "Regulatory Compliance",
+    version: "2.0.0",
+  },
+  policyDefinitionGroups: [
+    {
+      name: "NetworkSecurity",
+      displayName: "Network Security Policies",
+      category: "Network",
+      description: "Policies for network security controls",
+    },
+    {
+      name: "DataProtection",
+      displayName: "Data Protection Policies",
+      category: "Data",
+      description: "Policies for data protection and encryption",
+    },
+    {
+      name: "IdentityAndAccess",
+      displayName: "Identity & Access Policies",
+      category: "IAM",
+      description: "Policies for identity and access management",
+    },
+  ],
+  policyDefinitions: [
+    {
+      policyDefinitionId: "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+      policyDefinitionReferenceId: "networkSecurityPolicy1",
+      groupNames: ["NetworkSecurity"],
+    },
+    {
+      policyDefinitionId: "/providers/Microsoft.Authorization/policyDefinitions/policy-2",
+      policyDefinitionReferenceId: "dataProtectionPolicy1",
+      groupNames: ["DataProtection"],
+    },
+    {
+      policyDefinitionId: "/providers/Microsoft.Authorization/policyDefinitions/policy-3",
+      policyDefinitionReferenceId: "crossCuttingPolicy",
+      groupNames: ["NetworkSecurity", "DataProtection"],
+    },
+  ],
+});
+```
+
+### Combining Custom and Built-in Policies
+
+```typescript
+import { PolicyDefinition } from "@microsoft/terraform-cdk-constructs/azure-policydefinition";
+
+// Create a custom policy definition first
+const customPolicy = new PolicyDefinition(stack, "custom-audit-policy", {
+  displayName: "Audit Custom Tag",
+  scope: "/subscriptions/00000000-0000-0000-0000-000000000000",
+  policyRule: {
+    if: {
+      field: "tags['department']",
+      exists: "false",
+    },
+    then: {
+      effect: "audit",
+    },
+  },
+});
+
+// Create an initiative that combines the custom policy with built-in policies
+const initiative = new PolicySetDefinition(stack, "combined-initiative", {
+  displayName: "Combined Policies Initiative",
+  scope: "/subscriptions/00000000-0000-0000-0000-000000000000",
+  policyDefinitions: [
+    {
+      // Reference the custom policy
+      policyDefinitionId: customPolicy.id,
+      policyDefinitionReferenceId: "customAuditTag",
+    },
+    {
+      // Built-in policy
+      policyDefinitionId: "/providers/Microsoft.Authorization/policyDefinitions/06a78e20-9358-41c9-923c-fb736d382a4d",
+      policyDefinitionReferenceId: "builtInAuditVMs",
+    },
+  ],
+});
+```
+
+### Management Group Scope
+
+```typescript
+const mgInitiative = new PolicySetDefinition(stack, "mg-initiative", {
+  displayName: "Organization-wide Initiative",
+  description: "Applies to all subscriptions in the management group",
+  scope: "/providers/Microsoft.Management/managementGroups/my-management-group",
+  policyDefinitions: [
+    {
+      policyDefinitionId: "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+      policyDefinitionReferenceId: "orgPolicy1",
+    },
+  ],
+});
+```
+
+### Pinning to a Specific API Version
+
+```typescript
+const initiative = new PolicySetDefinition(stack, "pinned-initiative", {
+  displayName: "Stable Initiative",
+  scope: "/subscriptions/00000000-0000-0000-0000-000000000000",
+  apiVersion: "2021-06-01", // Pin to specific version
+  policyDefinitions: [
+    {
+      policyDefinitionId: "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+    },
+  ],
+});
+```
+
+### Using Outputs for Policy Assignment
+
+```typescript
+import { TerraformOutput } from "cdktn";
+
+const initiative = new PolicySetDefinition(stack, "initiative", {
+  displayName: "My Initiative",
+  scope: subscriptionId,
+  policyDefinitions: [
+    {
+      policyDefinitionId: "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+    },
+  ],
+});
+
+// Use the initiative ID in a policy assignment
+// The policySetDefinitionId property can be referenced from other resources
+console.log(initiative.policySetDefinitionId); // Terraform interpolation string
+
+// Create outputs for cross-stack references
+new TerraformOutput(stack, "initiative-id", {
+  value: initiative.idOutput,
+});
+```
+
+## API Reference
+
+### PolicySetDefinitionProps
+
+Configuration properties for the Policy Set Definition construct.
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `name` | `string` | No | Resource name. Auto-generated as UUID if not provided. |
+| `displayName` | `string` | Yes | Display name shown in Azure Portal. |
+| `description` | `string` | No | Description of the initiative. |
+| `scope` | `string` | Yes | Subscription or management group scope for the definition. |
+| `policyType` | `"BuiltIn" \| "Custom" \| "Static"` | No | Type of policy set. Default: "Custom". |
+| `metadata` | `PolicySetMetadata` | No | Metadata for categorization. |
+| `parameters` | `{ [key: string]: PolicySetParameterDefinition }` | No | Initiative parameter definitions. |
+| `policyDefinitions` | `PolicyDefinitionReference[]` | Yes | Array of policy definition references. |
+| `policyDefinitionGroups` | `PolicyDefinitionGroup[]` | No | Groups for organizing policies. |
+| `tags` | `{ [key: string]: string }` | No | Resource tags. |
+| `apiVersion` | `string` | No | Pin to a specific API version. |
+
+### PolicyDefinitionReference
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `policyDefinitionId` | `string` | Yes | ID of the policy definition to include. |
+| `policyDefinitionReferenceId` | `string` | No | Unique ID within the set. |
+| `parameters` | `{ [key: string]: PolicyParameterValue }` | No | Parameter values for this policy. |
+| `groupNames` | `string[]` | No | Groups this policy belongs to. |
+
+### PolicyDefinitionGroup
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `name` | `string` | Yes | Unique group name within the set. |
+| `displayName` | `string` | No | Display name in Azure Portal. |
+| `category` | `string` | No | Category for organization. |
+| `description` | `string` | No | Description of the group. |
+
+### PolicySetMetadata
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `category` | `string` | No | Category for Azure Portal organization. |
+| `version` | `string` | No | Version of the initiative. |
+| `preview` | `boolean` | No | Whether this is a preview initiative. |
+| `deprecated` | `boolean` | No | Whether this initiative is deprecated. |
+
+### PolicySetParameterDefinition
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `type` | `string` | Yes | Data type: String, Array, Object, Boolean, Integer, Float, DateTime. |
+| `displayName` | `string` | No | Display name in Azure Portal. |
+| `description` | `string` | No | Parameter description. |
+| `defaultValue` | `any` | No | Default value for the parameter. |
+| `allowedValues` | `any[]` | No | Allowed values for the parameter. |
+| `metadata` | `object` | No | Additional metadata (e.g., strongType). |
+
+### Public Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `string` | The Azure resource ID of the policy set definition. |
+| `policySetDefinitionId` | `string` | Alias for id, for use in policy assignments. |
+| `displayName` | `string` | The display name of the initiative. |
+| `policyType` | `string` | The policy type (Custom, BuiltIn, Static). |
+| `policyDefinitionCount` | `number` | Number of policy definitions in this set. |
+| `props` | `PolicySetDefinitionProps` | The original input properties. |
+| `resolvedApiVersion` | `string` | The API version being used. |
+
+### Outputs
+
+The construct automatically creates Terraform outputs:
+
+- `id`: The policy set definition resource ID
+- `name`: The policy set definition resource name
+- `policy_set_definition_id`: The ID for use in policy assignments
+
+## Best Practices
+
+### 1. Use Descriptive Reference IDs
+
+```typescript
+policyDefinitions: [
+  {
+    policyDefinitionId: "...",
+    policyDefinitionReferenceId: "auditStorageAccountEncryption", // Descriptive name
+  },
+]
+```
+
+### 2. Organize with Groups
+
+Use policy definition groups to categorize policies for better management and compliance reporting:
+
+```typescript
+policyDefinitionGroups: [
+  { name: "Security", category: "Security Center" },
+  { name: "Compliance", category: "Regulatory" },
+  { name: "CostManagement", category: "Cost" },
+],
+```
+
+### 3. Use Initiative Parameters
+
+Define parameters at the initiative level to allow flexibility during assignment:
+
+```typescript
+parameters: {
+  effect: {
+    type: "String",
+    defaultValue: "Audit",
+    allowedValues: ["Audit", "Deny", "Disabled"],
+  },
+},
+```
+
+### 4. Version Your Initiatives
+
+Use metadata to track initiative versions:
+
+```typescript
+metadata: {
+  category: "Security",
+  version: "1.0.0",
+},
+```
+
+### 5. Use Management Group Scope for Enterprise
+
+For organization-wide initiatives, create them at management group level:
+
+```typescript
+scope: "/providers/Microsoft.Management/managementGroups/root-mg",
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Empty policyDefinitions**: At least one policy definition reference is required.
+
+2. **Invalid Group Reference**: Ensure all groupNames in policy definitions exist in policyDefinitionGroups.
+
+3. **Duplicate Group Names**: Each group name must be unique within the policy set.
+
+4. **Missing policyDefinitionId**: Every policy definition reference requires a policyDefinitionId.
+
+5. **API Version Errors**: Ensure the version is 2023-04-01 or 2021-06-01.
+
+## Related Constructs
+
+- [`PolicyDefinition`](../azure-policydefinition/README.md) - Create custom policy definitions
+- [`PolicyAssignment`](../azure-policyassignment/README.md) - Assign policies and initiatives
+- [`ResourceGroup`](../azure-resourcegroup/README.md) - Azure Resource Groups
+
+## Additional Resources
+
+- [Azure Policy Documentation](https://learn.microsoft.com/en-us/azure/governance/policy/overview)
+- [Azure Policy Initiative Definition](https://learn.microsoft.com/en-us/azure/governance/policy/concepts/initiative-definition-structure)
+- [Azure REST API Reference](https://learn.microsoft.com/en-us/rest/api/policy/policy-set-definitions)
+- [Terraform CDK Documentation](https://developer.hashicorp.com/terraform/cdktf)
+
+## Contributing
+
+Contributions are welcome! Please see the [Contributing Guide](../../CONTRIBUTING.md) for details.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](../../LICENSE) file for details.

--- a/src/azure-policysetdefinition/index.ts
+++ b/src/azure-policysetdefinition/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Azure Policy Set Definition (Initiative) module
+ *
+ * This module provides constructs for creating and managing Azure Policy Set Definitions
+ * (also known as Initiatives in Azure Portal).
+ *
+ * Policy Set Definitions allow you to group multiple policy definitions together
+ * and assign them as a single unit for easier governance and compliance management.
+ */
+
+export * from "./lib";

--- a/src/azure-policysetdefinition/lib/index.ts
+++ b/src/azure-policysetdefinition/lib/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Azure Policy Set Definition (Initiative) construct exports
+ */
+
+export * from "./policy-set-definition-schemas";
+export * from "./policy-set-definition";

--- a/src/azure-policysetdefinition/lib/policy-set-definition-schemas.ts
+++ b/src/azure-policysetdefinition/lib/policy-set-definition-schemas.ts
@@ -1,0 +1,283 @@
+/**
+ * API schemas for Azure Policy Set Definition (Initiative) across all supported versions
+ *
+ * This file defines the complete API schemas for Microsoft.Authorization/policySetDefinitions
+ * across all supported API versions. The schemas are used by the AzapiResource
+ * framework for validation, transformation, and version management.
+ *
+ * Policy Set Definitions (also known as Initiatives) are collections of policy definitions
+ * that allow you to group policies and assign them together as a single unit.
+ */
+
+import {
+  ApiSchema,
+  PropertyDefinition,
+  PropertyType,
+  ValidationRuleType,
+  VersionConfig,
+  VersionSupportLevel,
+} from "../../core-azure/lib/version-manager/interfaces/version-interfaces";
+
+// =============================================================================
+// COMMON PROPERTY DEFINITIONS
+// =============================================================================
+
+/**
+ * Common property definitions shared across all Policy Set Definition versions
+ */
+const COMMON_PROPERTIES: { [key: string]: PropertyDefinition } = {
+  name: {
+    dataType: PropertyType.STRING,
+    required: false,
+    description:
+      "The name of the policy set definition resource. Automatically generated as a GUID if not provided.",
+    validation: [],
+  },
+  displayName: {
+    dataType: PropertyType.STRING,
+    required: true,
+    description:
+      "The display name of the policy set definition shown in the Azure portal",
+    validation: [
+      {
+        ruleType: ValidationRuleType.REQUIRED,
+        message: "Display name is required for policy set definitions",
+      },
+      {
+        ruleType: ValidationRuleType.VALUE_RANGE,
+        value: { minLength: 1, maxLength: 128 },
+        message: "Display name must be between 1 and 128 characters",
+      },
+    ],
+  },
+  description: {
+    dataType: PropertyType.STRING,
+    required: false,
+    description:
+      "The description of the policy set definition explaining its purpose and scope",
+    validation: [
+      {
+        ruleType: ValidationRuleType.VALUE_RANGE,
+        value: { minLength: 0, maxLength: 512 },
+        message: "Description must not exceed 512 characters",
+      },
+    ],
+  },
+  policyType: {
+    dataType: PropertyType.STRING,
+    required: false,
+    defaultValue: "Custom",
+    description:
+      "The type of policy set definition. Valid values: BuiltIn, Custom, Static",
+    validation: [
+      {
+        ruleType: ValidationRuleType.PATTERN_MATCH,
+        value: "^(BuiltIn|Custom|Static)$",
+        message: "Policy type must be BuiltIn, Custom, or Static",
+      },
+    ],
+  },
+  metadata: {
+    dataType: PropertyType.OBJECT,
+    required: false,
+    description:
+      "Metadata object for categorization including category, version, preview, and deprecated flags",
+  },
+  parameters: {
+    dataType: PropertyType.OBJECT,
+    required: false,
+    description:
+      "Parameter definitions that can be used by policy definitions in the set",
+  },
+  policyDefinitions: {
+    dataType: PropertyType.ARRAY,
+    required: true,
+    description:
+      "Array of policy definition references included in this policy set",
+    validation: [
+      {
+        ruleType: ValidationRuleType.REQUIRED,
+        message:
+          "Policy definitions array is required for policy set definitions",
+      },
+      {
+        ruleType: ValidationRuleType.TYPE_CHECK,
+        value: PropertyType.ARRAY,
+        message:
+          "Policy definitions must be an array of policy definition references",
+      },
+    ],
+  },
+  policyDefinitionGroups: {
+    dataType: PropertyType.ARRAY,
+    required: false,
+    description:
+      "Groups for organizing policy definitions within the policy set",
+  },
+};
+
+// =============================================================================
+// VERSION-SPECIFIC SCHEMAS
+// =============================================================================
+
+/**
+ * API Schema for Policy Set Definition version 2023-04-01
+ *
+ * This is the latest stable version for Policy Set Definitions.
+ * It includes support for:
+ * - Policy definition references with parameters
+ * - Policy definition groups for organization
+ * - Metadata for categorization
+ * - Parameter definitions for the initiative
+ */
+export const POLICY_SET_DEFINITION_SCHEMA_2023_04_01: ApiSchema = {
+  resourceType: "Microsoft.Authorization/policySetDefinitions",
+  version: "2023-04-01",
+  properties: {
+    ...COMMON_PROPERTIES,
+  },
+  required: ["displayName", "policyDefinitions"],
+  optional: [
+    "name",
+    "description",
+    "policyType",
+    "metadata",
+    "parameters",
+    "policyDefinitionGroups",
+  ],
+  deprecated: [],
+  transformationRules: {},
+  validationRules: [
+    {
+      property: "displayName",
+      rules: [
+        {
+          ruleType: ValidationRuleType.REQUIRED,
+          message: "Display name is required for policy set definitions",
+        },
+      ],
+    },
+    {
+      property: "policyDefinitions",
+      rules: [
+        {
+          ruleType: ValidationRuleType.REQUIRED,
+          message:
+            "Policy definitions array is required for policy set definitions",
+        },
+      ],
+    },
+  ],
+};
+
+/**
+ * API Schema for Policy Set Definition version 2021-06-01
+ *
+ * This is a stable version for backward compatibility.
+ * It includes support for:
+ * - Policy definition references with parameters
+ * - Policy definition groups for organization
+ * - Metadata for categorization
+ * - Parameter definitions for the initiative
+ */
+export const POLICY_SET_DEFINITION_SCHEMA_2021_06_01: ApiSchema = {
+  resourceType: "Microsoft.Authorization/policySetDefinitions",
+  version: "2021-06-01",
+  properties: {
+    ...COMMON_PROPERTIES,
+  },
+  required: ["displayName", "policyDefinitions"],
+  optional: [
+    "name",
+    "description",
+    "policyType",
+    "metadata",
+    "parameters",
+    "policyDefinitionGroups",
+  ],
+  deprecated: [],
+  transformationRules: {},
+  validationRules: [
+    {
+      property: "displayName",
+      rules: [
+        {
+          ruleType: ValidationRuleType.REQUIRED,
+          message: "Display name is required for policy set definitions",
+        },
+      ],
+    },
+    {
+      property: "policyDefinitions",
+      rules: [
+        {
+          ruleType: ValidationRuleType.REQUIRED,
+          message:
+            "Policy definitions array is required for policy set definitions",
+        },
+      ],
+    },
+  ],
+};
+
+// =============================================================================
+// VERSION CONFIGURATIONS
+// =============================================================================
+
+/**
+ * Version configuration for Policy Set Definition 2023-04-01
+ */
+export const POLICY_SET_DEFINITION_VERSION_2023_04_01: VersionConfig = {
+  version: "2023-04-01",
+  schema: POLICY_SET_DEFINITION_SCHEMA_2023_04_01,
+  supportLevel: VersionSupportLevel.ACTIVE,
+  releaseDate: "2023-04-01",
+  deprecationDate: undefined,
+  sunsetDate: undefined,
+  breakingChanges: [],
+  migrationGuide: "/docs/policy-set-definition/migration-2023-04-01",
+  changeLog: [
+    {
+      changeType: "updated",
+      description:
+        "Latest stable API version for Policy Set Definitions with enhanced validation",
+      breaking: false,
+    },
+  ],
+};
+
+/**
+ * Version configuration for Policy Set Definition 2021-06-01
+ */
+export const POLICY_SET_DEFINITION_VERSION_2021_06_01: VersionConfig = {
+  version: "2021-06-01",
+  schema: POLICY_SET_DEFINITION_SCHEMA_2021_06_01,
+  supportLevel: VersionSupportLevel.ACTIVE,
+  releaseDate: "2021-06-01",
+  deprecationDate: undefined,
+  sunsetDate: undefined,
+  breakingChanges: [],
+  migrationGuide: "/docs/policy-set-definition/migration-2021-06-01",
+  changeLog: [
+    {
+      changeType: "updated",
+      description: "Stable API version for backward compatibility",
+      breaking: false,
+    },
+  ],
+};
+
+/**
+ * All supported Policy Set Definition versions for registration
+ * Ordered with latest stable version first
+ */
+export const ALL_POLICY_SET_DEFINITION_VERSIONS: VersionConfig[] = [
+  POLICY_SET_DEFINITION_VERSION_2023_04_01,
+  POLICY_SET_DEFINITION_VERSION_2021_06_01,
+];
+
+/**
+ * Resource type constant
+ */
+export const POLICY_SET_DEFINITION_TYPE =
+  "Microsoft.Authorization/policySetDefinitions";

--- a/src/azure-policysetdefinition/lib/policy-set-definition.ts
+++ b/src/azure-policysetdefinition/lib/policy-set-definition.ts
@@ -1,0 +1,658 @@
+/**
+ * Unified Azure Policy Set Definition (Initiative) implementation using AzapiResource framework
+ *
+ * This class provides a version-aware implementation for Azure Policy Set Definitions
+ * that automatically handles version management, schema validation, and property
+ * transformation across all supported API versions.
+ *
+ * Policy Set Definitions (also known as Initiatives in Azure Portal) allow you to
+ * group multiple policy definitions together and assign them as a single unit.
+ *
+ * Supported API Versions:
+ * - 2023-04-01 (Active, Latest)
+ * - 2021-06-01 (Active, Backward Compatibility)
+ *
+ * Features:
+ * - Automatic latest version resolution when no version is specified
+ * - Explicit version pinning for stability requirements
+ * - Schema-driven validation and transformation
+ * - Full JSII compliance for multi-language support
+ * - Support for policy definition references with parameters
+ * - Policy definition groups for organization
+ * - Initiative-level parameter definitions
+ */
+
+import { createHash } from "crypto";
+import * as cdktf from "cdktn";
+import { Construct } from "constructs";
+import {
+  ALL_POLICY_SET_DEFINITION_VERSIONS,
+  POLICY_SET_DEFINITION_TYPE,
+} from "./policy-set-definition-schemas";
+import {
+  AzapiResource,
+  AzapiResourceProps,
+} from "../../core-azure/lib/azapi/azapi-resource";
+import { ApiSchema } from "../../core-azure/lib/version-manager/interfaces/version-interfaces";
+
+/**
+ * A reference to a policy definition within a policy set
+ *
+ * This defines which policy definitions are included in the initiative
+ * and how they are configured with parameters.
+ */
+export interface PolicyDefinitionReference {
+  /**
+   * The ID of the policy definition to include in the set
+   *
+   * This can be:
+   * - A built-in policy: /providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionId}
+   * - A custom policy at subscription level: /subscriptions/{subscriptionId}/providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionId}
+   * - A custom policy at management group level: /providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionId}
+   *
+   * @example "/providers/Microsoft.Authorization/policyDefinitions/06a78e20-9358-41c9-923c-fb736d382a4d"
+   */
+  readonly policyDefinitionId: string;
+
+  /**
+   * A unique identifier for this policy definition reference within the set
+   *
+   * This ID is used to reference this specific policy in the initiative
+   * and must be unique within the policy set definition.
+   *
+   * @example "auditVMsWithoutTags"
+   */
+  readonly policyDefinitionReferenceId?: string;
+
+  /**
+   * Parameter values for this policy definition
+   *
+   * These values override the default parameter values in the policy definition.
+   * Parameters can reference initiative-level parameters using the format:
+   * { "value": "[parameters('initiativeParameterName')]" }
+   *
+   * @example { "tagName": { "value": "environment" }, "tagValue": { "value": "[parameters('requiredTagValue')]" } }
+   */
+  readonly parameters?: { [key: string]: PolicyParameterValue };
+
+  /**
+   * Group names that this policy definition belongs to
+   *
+   * Groups help organize policies within an initiative and can be used
+   * for compliance reporting and management.
+   *
+   * @example ["Security", "Compliance"]
+   */
+  readonly groupNames?: string[];
+}
+
+/**
+ * A group for organizing policy definitions within a policy set
+ *
+ * Groups provide a way to categorize and organize policies within an initiative
+ * for better management and compliance reporting.
+ */
+export interface PolicyDefinitionGroup {
+  /**
+   * The name of the group (must be unique within the policy set)
+   *
+   * This name is referenced by policy definitions to indicate membership.
+   *
+   * @example "Security"
+   */
+  readonly name: string;
+
+  /**
+   * The display name of the group shown in Azure Portal
+   *
+   * @example "Security Policies"
+   */
+  readonly displayName?: string;
+
+  /**
+   * The category this group belongs to
+   *
+   * Categories help organize groups and are displayed in the Azure Portal.
+   *
+   * @example "Security Center"
+   */
+  readonly category?: string;
+
+  /**
+   * A description of the group's purpose
+   *
+   * @example "Policies related to security configuration and compliance"
+   */
+  readonly description?: string;
+
+  /**
+   * Additional metadata for the group
+   */
+  readonly additionalMetadataId?: string;
+}
+
+/**
+ * Metadata for the policy set definition
+ *
+ * Metadata provides additional information about the policy set
+ * without affecting its evaluation logic.
+ */
+export interface PolicySetMetadata {
+  /**
+   * The category of the policy set for Azure Portal organization
+   *
+   * @example "Security Center"
+   */
+  readonly category?: string;
+
+  /**
+   * The version of the policy set definition
+   *
+   * @example "1.0.0"
+   */
+  readonly version?: string;
+
+  /**
+   * Whether this policy set is in preview
+   *
+   * @default false
+   */
+  readonly preview?: boolean;
+
+  /**
+   * Whether this policy set is deprecated
+   *
+   * @default false
+   */
+  readonly deprecated?: boolean;
+}
+
+/**
+ * Metadata for a policy set parameter
+ *
+ * Provides additional information for Azure Portal integration.
+ */
+export interface PolicySetParameterMetadata {
+  /**
+   * Strong type for Azure Portal resource picker integration
+   */
+  readonly strongType?: string;
+
+  /**
+   * Display name in Azure Portal
+   */
+  readonly displayName?: string;
+
+  /**
+   * Description in Azure Portal
+   */
+  readonly description?: string;
+}
+
+/**
+ * Parameter definition for the policy set
+ *
+ * These parameters can be referenced by policy definitions within the set.
+ */
+export interface PolicySetParameterDefinition {
+  /**
+   * The data type of the parameter
+   */
+  readonly type:
+    | "String"
+    | "Array"
+    | "Object"
+    | "Boolean"
+    | "Integer"
+    | "Float"
+    | "DateTime";
+
+  /**
+   * Display name for the parameter in Azure Portal
+   */
+  readonly displayName?: string;
+
+  /**
+   * Description of the parameter
+   */
+  readonly description?: string;
+
+  /**
+   * Default value for the parameter
+   */
+  readonly defaultValue?: any;
+
+  /**
+   * Allowed values for the parameter
+   */
+  readonly allowedValues?: any[];
+
+  /**
+   * Metadata for the parameter (e.g., strongType for Azure Portal integration)
+   */
+  readonly metadata?: PolicySetParameterMetadata;
+}
+
+/**
+ * A parameter value, either a direct value or a reference
+ */
+export interface PolicyParameterValue {
+  /**
+   * The value of the parameter
+   *
+   * Can be a direct value or a reference to an initiative parameter
+   * using the format: "[parameters('parameterName')]"
+   */
+  readonly value: any;
+}
+
+/**
+ * Properties for the unified Azure Policy Set Definition
+ *
+ * Extends AzapiResourceProps with Policy Set Definition specific properties
+ */
+export interface PolicySetDefinitionProps extends AzapiResourceProps {
+  /**
+   * The scope at which to create the policy set definition
+   *
+   * This can be:
+   * - A subscription: /subscriptions/{subscriptionId}
+   * - A management group: /providers/Microsoft.Management/managementGroups/{managementGroupId}
+   *
+   * @example "/subscriptions/00000000-0000-0000-0000-000000000000"
+   * @example "/providers/Microsoft.Management/managementGroups/my-management-group"
+   */
+  readonly scope: string;
+
+  /**
+   * The display name of the policy set definition
+   *
+   * This is the name shown in the Azure Portal.
+   * Required property.
+   *
+   * @example "Security Baseline Initiative"
+   */
+  readonly displayName: string;
+
+  /**
+   * Description of the policy set definition
+   *
+   * @example "This initiative applies a set of security policies to ensure baseline compliance."
+   */
+  readonly description?: string;
+
+  /**
+   * The type of policy set definition
+   *
+   * @default "Custom"
+   */
+  readonly policyType?: "BuiltIn" | "Custom" | "Static";
+
+  /**
+   * Metadata for the policy set definition
+   *
+   * Includes category, version, preview, and deprecated flags.
+   */
+  readonly metadata?: PolicySetMetadata;
+
+  /**
+   * Parameter definitions for the policy set
+   *
+   * These parameters can be referenced by policy definitions in the set
+   * using the format: "[parameters('parameterName')]"
+   */
+  readonly parameters?: { [key: string]: PolicySetParameterDefinition };
+
+  /**
+   * Array of policy definition references
+   *
+   * Each reference specifies a policy definition to include in the set
+   * along with its parameter values and group memberships.
+   * Required property.
+   */
+  readonly policyDefinitions: PolicyDefinitionReference[];
+
+  /**
+   * Groups for organizing policy definitions in the set
+   *
+   * Groups help categorize policies for management and compliance reporting.
+   */
+  readonly policyDefinitionGroups?: PolicyDefinitionGroup[];
+}
+
+/**
+ * Properties interface for Azure Policy Set Definition
+ * This is required for JSII compliance to support multi-language code generation
+ */
+export interface PolicySetDefinitionProperties {
+  /**
+   * The display name of the policy set definition
+   */
+  readonly displayName: string;
+
+  /**
+   * Description of the policy set definition
+   */
+  readonly description?: string;
+
+  /**
+   * The type of policy set definition
+   */
+  readonly policyType?: string;
+
+  /**
+   * Metadata for the policy set definition
+   */
+  readonly metadata?: PolicySetMetadata;
+
+  /**
+   * Parameter definitions for the policy set
+   */
+  readonly parameters?: { [key: string]: PolicySetParameterDefinition };
+
+  /**
+   * Array of policy definition references
+   */
+  readonly policyDefinitions: PolicyDefinitionReference[];
+
+  /**
+   * Groups for organizing policy definitions
+   */
+  readonly policyDefinitionGroups?: PolicyDefinitionGroup[];
+}
+
+/**
+ * The resource body interface for Azure Policy Set Definition API calls
+ * This matches the Azure REST API schema for policy set definitions
+ */
+export interface PolicySetDefinitionBody {
+  /**
+   * The properties of the policy set definition
+   */
+  readonly properties: PolicySetDefinitionProperties;
+}
+
+/**
+ * Unified Azure Policy Set Definition (Initiative) implementation
+ *
+ * This class provides a single, version-aware implementation for managing Azure
+ * Policy Set Definitions. It automatically handles version resolution, schema validation,
+ * and property transformation.
+ *
+ * Policy Set Definitions allow you to group multiple policy definitions together
+ * and assign them as a single unit (also known as "Initiatives" in Azure Portal).
+ *
+ * Note: Policy set definitions are created at subscription or management group scope.
+ * They do not have a location property as they are not region-specific.
+ *
+ * @example
+ * const initiative = new PolicySetDefinition(this, "security-initiative", {
+ *   displayName: "Security Baseline",
+ *   scope: "/subscriptions/00000000-0000-0000-0000-000000000000",
+ *   policyDefinitions: [
+ *     {
+ *       policyDefinitionId: "/providers/Microsoft.Authorization/policyDefinitions/abc123",
+ *       policyDefinitionReferenceId: "auditVMsWithoutExtensions",
+ *     },
+ *   ],
+ * });
+ *
+ * @stability stable
+ */
+export class PolicySetDefinition extends AzapiResource {
+  static {
+    AzapiResource.registerSchemas(
+      POLICY_SET_DEFINITION_TYPE,
+      ALL_POLICY_SET_DEFINITION_VERSIONS,
+    );
+  }
+
+  /**
+   * The input properties for this Policy Set Definition instance
+   */
+  public readonly props: PolicySetDefinitionProps;
+
+  // Output properties for easy access and referencing
+  public readonly idOutput: cdktf.TerraformOutput;
+  public readonly nameOutput: cdktf.TerraformOutput;
+  public readonly policySetDefinitionIdOutput: cdktf.TerraformOutput;
+
+  /**
+   * Creates a new Azure Policy Set Definition using the AzapiResource framework
+   *
+   * The constructor automatically handles version resolution, schema registration,
+   * validation, and resource creation.
+   *
+   * @param scope - The scope in which to define this construct
+   * @param id - The unique identifier for this instance
+   * @param props - Configuration properties for the Policy Set Definition
+   */
+  constructor(scope: Construct, id: string, props: PolicySetDefinitionProps) {
+    // Validate required properties
+    if (!props.displayName || props.displayName.trim() === "") {
+      throw new Error("displayName is required for policy set definitions");
+    }
+
+    if (!props.policyDefinitions || props.policyDefinitions.length === 0) {
+      throw new Error(
+        "At least one policy definition reference is required in policyDefinitions",
+      );
+    }
+
+    // Validate policy definition references
+    props.policyDefinitions.forEach((policyDef, index) => {
+      if (!policyDef.policyDefinitionId) {
+        throw new Error(
+          `policyDefinitionId is required for policy definition at index ${index}`,
+        );
+      }
+    });
+
+    // Validate policy definition groups if provided
+    if (props.policyDefinitionGroups) {
+      const groupNames = new Set<string>();
+      props.policyDefinitionGroups.forEach((group, index) => {
+        if (!group.name) {
+          throw new Error(
+            `name is required for policy definition group at index ${index}`,
+          );
+        }
+        if (groupNames.has(group.name)) {
+          throw new Error(
+            `Duplicate group name '${group.name}' in policyDefinitionGroups`,
+          );
+        }
+        groupNames.add(group.name);
+      });
+
+      // Validate that policy definitions reference valid groups
+      const validGroupNames = Array.from(groupNames);
+      props.policyDefinitions.forEach((policyDef, index) => {
+        if (policyDef.groupNames) {
+          policyDef.groupNames.forEach((groupName) => {
+            if (!validGroupNames.includes(groupName)) {
+              throw new Error(
+                `Policy definition at index ${index} references unknown group '${groupName}'. Valid groups are: ${validGroupNames.join(", ")}`,
+              );
+            }
+          });
+        }
+      });
+    }
+
+    super(scope, id, props);
+
+    this.props = props;
+
+    // Create Terraform outputs for easy access and referencing from other resources
+    this.idOutput = new cdktf.TerraformOutput(this, "id", {
+      value: this.id,
+      description: "The ID of the Policy Set Definition",
+    });
+
+    this.nameOutput = new cdktf.TerraformOutput(this, "name", {
+      value: `\${${this.terraformResource.fqn}.name}`,
+      description: "The name of the Policy Set Definition",
+    });
+
+    this.policySetDefinitionIdOutput = new cdktf.TerraformOutput(
+      this,
+      "policy_set_definition_id",
+      {
+        value: this.id,
+        description:
+          "The Policy Set Definition ID (same as id, for use in policy assignments)",
+      },
+    );
+
+    // Override logical IDs to match original naming convention
+    this.idOutput.overrideLogicalId("id");
+    this.nameOutput.overrideLogicalId("name");
+    this.policySetDefinitionIdOutput.overrideLogicalId(
+      "policy_set_definition_id",
+    );
+  }
+
+  // =============================================================================
+  // REQUIRED ABSTRACT METHODS FROM AzapiResource
+  // =============================================================================
+
+  /**
+   * Gets the default API version to use when no explicit version is specified
+   * Returns the most recent stable version as the default
+   */
+  protected defaultVersion(): string {
+    return "2023-04-01";
+  }
+
+  /**
+   * Gets the Azure resource type for Policy Set Definitions
+   */
+  protected resourceType(): string {
+    return POLICY_SET_DEFINITION_TYPE;
+  }
+
+  /**
+   * Gets the API schema for the resolved version
+   * Uses the framework's schema resolution to get the appropriate schema
+   */
+  protected apiSchema(): ApiSchema {
+    return this.resolveSchema();
+  }
+
+  /**
+   * Overrides the name resolution to generate deterministic GUIDs for policy set definitions
+   *
+   * Policy set definitions can use custom names or auto-generated GUIDs.
+   * This implementation generates a deterministic UUID based on the policy set definition's
+   * key properties if no name is provided.
+   */
+  protected resolveName(props: AzapiResourceProps): string {
+    const typedProps = props as PolicySetDefinitionProps;
+
+    // If name is provided, use it
+    if (typedProps.name) {
+      return typedProps.name;
+    }
+
+    // Generate a deterministic GUID based on display name and scope
+    const hashInput = [typedProps.displayName, typedProps.scope].join("|");
+
+    const hash = createHash("sha256").update(hashInput).digest("hex");
+
+    // Convert hash to UUID format (8-4-4-4-12)
+    return [
+      hash.substring(0, 8),
+      hash.substring(8, 12),
+      hash.substring(12, 16),
+      hash.substring(16, 20),
+      hash.substring(20, 32),
+    ].join("-");
+  }
+
+  /**
+   * Creates the resource body for the Azure API call
+   * Transforms the input properties into the JSON format expected by Azure REST API
+   *
+   * Note: Policy set definitions do not have a location property as they are
+   * scope-specific resources deployed at subscription or management group level.
+   */
+  protected createResourceBody(props: any): any {
+    const typedProps = props as PolicySetDefinitionProps;
+
+    const body: any = {
+      properties: {
+        displayName: typedProps.displayName,
+        policyType: typedProps.policyType || "Custom",
+        policyDefinitions: typedProps.policyDefinitions,
+      },
+    };
+
+    // Add optional properties only if specified
+    if (typedProps.description) {
+      body.properties.description = typedProps.description;
+    }
+
+    if (typedProps.metadata) {
+      body.properties.metadata = typedProps.metadata;
+    }
+
+    if (typedProps.parameters) {
+      body.properties.parameters = typedProps.parameters;
+    }
+
+    if (
+      typedProps.policyDefinitionGroups &&
+      typedProps.policyDefinitionGroups.length > 0
+    ) {
+      body.properties.policyDefinitionGroups =
+        typedProps.policyDefinitionGroups;
+    }
+
+    return body;
+  }
+
+  /**
+   * Resolves the parent resource ID for Policy Set Definition
+   * Policy Set Definitions are created at subscription or management group scope
+   *
+   * @param props - The resource properties
+   * @returns The parent resource ID (the scope)
+   */
+  protected resolveParentId(props: any): string {
+    return (props as PolicySetDefinitionProps).scope;
+  }
+
+  // =============================================================================
+  // PUBLIC METHODS FOR POLICY SET DEFINITION OPERATIONS
+  // =============================================================================
+
+  /**
+   * Get the full resource identifier for use in policy assignments
+   * Alias for the id property
+   */
+  public get policySetDefinitionId(): string {
+    return this.id;
+  }
+
+  /**
+   * Get the display name of the policy set definition
+   */
+  public get displayName(): string {
+    return this.props.displayName;
+  }
+
+  /**
+   * Get the policy type
+   */
+  public get policyType(): string {
+    return this.props.policyType || "Custom";
+  }
+
+  /**
+   * Get the number of policy definitions in this set
+   */
+  public get policyDefinitionCount(): number {
+    return this.props.policyDefinitions.length;
+  }
+}

--- a/src/azure-policysetdefinition/test/policy-set-definition.integ.ts
+++ b/src/azure-policysetdefinition/test/policy-set-definition.integ.ts
@@ -1,0 +1,67 @@
+/**
+ * Integration test for Azure Policy Set Definition (Initiative)
+ *
+ * This test demonstrates basic usage of the PolicySetDefinition construct
+ * and validates deployment, idempotency, and cleanup.
+ *
+ * Run with: npm run integration:nostream
+ */
+
+import { Testing, TerraformStack } from "cdktn";
+import { Construct } from "constructs";
+import "cdktn/lib/testing/adapters/jest";
+import { DataAzapiClientConfig } from "../../core-azure/lib/azapi/providers-azapi/data-azapi-client-config";
+import { AzapiProvider } from "../../core-azure/lib/azapi/providers-azapi/provider";
+import { TerraformApplyCheckAndDestroy } from "../../testing";
+import { PolicySetDefinition } from "../lib/policy-set-definition";
+
+/**
+ * Example stack demonstrating Policy Set Definition usage
+ */
+class PolicySetDefinitionExampleStack extends TerraformStack {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    // Configure AZAPI provider
+    new AzapiProvider(this, "azapi", {});
+
+    // Create a client config to get the current subscription ID
+    const clientConfig = new DataAzapiClientConfig(this, "client_config", {});
+
+    // Use the current subscription for policy definitions
+    const subscriptionId = `/subscriptions/\${${clientConfig.fqn}.subscription_id}`;
+
+    // Basic Policy Set Definition with built-in policies
+    new PolicySetDefinition(this, "basic-initiative", {
+      displayName: "Basic Security Initiative",
+      description:
+        "A simple initiative to demonstrate Policy Set Definition construct",
+      scope: subscriptionId,
+      policyDefinitions: [
+        {
+          // Audit VMs that do not use managed disks
+          policyDefinitionId:
+            "/providers/Microsoft.Authorization/policyDefinitions/06a78e20-9358-41c9-923c-fb736d382a4d",
+          policyDefinitionReferenceId: "auditManagedDisks",
+        },
+      ],
+    });
+  }
+}
+
+describe("Policy Set Definition Integration Test", () => {
+  it("should deploy, validate idempotency, and cleanup Policy Set Definition resources", () => {
+    const app = Testing.app();
+    const stack = new PolicySetDefinitionExampleStack(
+      app,
+      "test-policy-set-definition",
+    );
+    const synthesized = Testing.fullSynth(stack);
+
+    // This will:
+    // 1. Run terraform apply to deploy resources
+    // 2. Run terraform plan to check idempotency (no changes expected)
+    // 3. Run terraform destroy to cleanup resources
+    TerraformApplyCheckAndDestroy(synthesized);
+  }, 600000); // 10 minute timeout for deployment and cleanup
+});

--- a/src/azure-policysetdefinition/test/policy-set-definition.spec.ts
+++ b/src/azure-policysetdefinition/test/policy-set-definition.spec.ts
@@ -1,0 +1,947 @@
+/**
+ * Comprehensive tests for the PolicySetDefinition implementation
+ *
+ * This test suite validates the PolicySetDefinition class using the AzapiResource framework.
+ * Tests cover automatic version resolution, explicit version pinning, schema validation,
+ * property configurations, and resource creation.
+ */
+
+import { Testing } from "cdktn";
+import * as cdktf from "cdktn";
+import {
+  PolicySetDefinition,
+  PolicySetDefinitionProps,
+} from "../lib/policy-set-definition";
+
+describe("PolicySetDefinition - Implementation", () => {
+  let app: cdktf.App;
+  let stack: cdktf.TerraformStack;
+
+  beforeEach(() => {
+    app = Testing.app();
+    stack = new cdktf.TerraformStack(app, "TestStack");
+  });
+
+  // =============================================================================
+  // Constructor and Basic Properties
+  // =============================================================================
+
+  describe("Constructor and Basic Properties", () => {
+    it("should create a Policy Set Definition with minimal configuration", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Test Initiative",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/test-policy-id",
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(stack, "TestPolicySet", props);
+
+      expect(policySet).toBeInstanceOf(PolicySetDefinition);
+      expect(policySet.props).toBe(props);
+      expect(policySet.displayName).toBe("Test Initiative");
+      expect(policySet.policyType).toBe("Custom");
+      expect(policySet.policyDefinitionCount).toBe(1);
+    });
+
+    it("should create a Policy Set Definition with description", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Security Initiative",
+        description: "Initiative for security compliance",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(
+        stack,
+        "SecurityPolicySet",
+        props,
+      );
+
+      expect(policySet.props.description).toBe(
+        "Initiative for security compliance",
+      );
+    });
+
+    it("should create a Policy Set Definition with custom name", () => {
+      const props: PolicySetDefinitionProps = {
+        name: "my-custom-initiative",
+        displayName: "Custom Named Initiative",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(
+        stack,
+        "CustomNamedPolicySet",
+        props,
+      );
+
+      expect(policySet.props.name).toBe("my-custom-initiative");
+    });
+
+    it("should create a Policy Set Definition with metadata", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Metadata Initiative",
+        scope: "/subscriptions/test-sub",
+        metadata: {
+          category: "Security Center",
+          version: "1.0.0",
+          preview: false,
+          deprecated: false,
+        },
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(
+        stack,
+        "MetadataPolicySet",
+        props,
+      );
+
+      expect(policySet.props.metadata?.category).toBe("Security Center");
+      expect(policySet.props.metadata?.version).toBe("1.0.0");
+      expect(policySet.props.metadata?.preview).toBe(false);
+    });
+  });
+
+  // =============================================================================
+  // Version Resolution
+  // =============================================================================
+
+  describe("Version Resolution", () => {
+    it("should use latest version 2023-04-01 when no version specified", () => {
+      const policySet = new PolicySetDefinition(stack, "DefaultVersion", {
+        displayName: "Default Version Initiative",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      });
+
+      expect(policySet.resolvedApiVersion).toBe("2023-04-01");
+    });
+
+    it("should use explicit version when specified", () => {
+      const policySet = new PolicySetDefinition(stack, "PinnedVersion", {
+        displayName: "Pinned Version Initiative",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+        apiVersion: "2021-06-01",
+      });
+
+      expect(policySet.resolvedApiVersion).toBe("2021-06-01");
+    });
+
+    it("should use latest version 2023-04-01 when explicitly specified", () => {
+      const policySet = new PolicySetDefinition(stack, "LatestVersion", {
+        displayName: "Latest Version Initiative",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+        apiVersion: "2023-04-01",
+      });
+
+      expect(policySet.resolvedApiVersion).toBe("2023-04-01");
+    });
+  });
+
+  // =============================================================================
+  // Validation Tests
+  // =============================================================================
+
+  describe("Validation", () => {
+    it("should throw error when displayName is empty", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      };
+
+      expect(() => {
+        new PolicySetDefinition(stack, "EmptyDisplayName", props);
+      }).toThrow(/displayName is required/);
+    });
+
+    it("should throw error when policyDefinitions is empty", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "No Policies Initiative",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [],
+      };
+
+      expect(() => {
+        new PolicySetDefinition(stack, "NoPolicies", props);
+      }).toThrow(/At least one policy definition reference is required/);
+    });
+
+    it("should throw error when policyDefinitionId is missing", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Invalid Policy Reference",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId: "",
+          },
+        ],
+      };
+
+      expect(() => {
+        new PolicySetDefinition(stack, "InvalidPolicyRef", props);
+      }).toThrow(/policyDefinitionId is required/);
+    });
+
+    it("should throw error for duplicate group names", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Duplicate Groups",
+        scope: "/subscriptions/test-sub",
+        policyDefinitionGroups: [
+          { name: "Security", displayName: "Security Policies" },
+          { name: "Security", displayName: "Duplicate Security" },
+        ],
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      };
+
+      expect(() => {
+        new PolicySetDefinition(stack, "DuplicateGroups", props);
+      }).toThrow(/Duplicate group name 'Security'/);
+    });
+
+    it("should throw error for invalid group reference in policy definition", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Invalid Group Reference",
+        scope: "/subscriptions/test-sub",
+        policyDefinitionGroups: [
+          { name: "Security", displayName: "Security Policies" },
+        ],
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+            groupNames: ["NonExistentGroup"],
+          },
+        ],
+      };
+
+      expect(() => {
+        new PolicySetDefinition(stack, "InvalidGroupRef", props);
+      }).toThrow(/references unknown group 'NonExistentGroup'/);
+    });
+
+    it("should accept valid policy set with groups", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Valid Groups Initiative",
+        scope: "/subscriptions/test-sub",
+        policyDefinitionGroups: [
+          { name: "Security", displayName: "Security Policies" },
+          { name: "Compliance", displayName: "Compliance Policies" },
+        ],
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+            groupNames: ["Security"],
+          },
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-2",
+            groupNames: ["Security", "Compliance"],
+          },
+        ],
+      };
+
+      expect(() => {
+        new PolicySetDefinition(stack, "ValidGroups", props);
+      }).not.toThrow();
+    });
+  });
+
+  // =============================================================================
+  // Policy Definition References
+  // =============================================================================
+
+  describe("Policy Definition References", () => {
+    it("should create initiative with single policy definition", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Single Policy Initiative",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+            policyDefinitionReferenceId: "allowedLocations",
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(stack, "SinglePolicy", props);
+      expect(policySet.policyDefinitionCount).toBe(1);
+    });
+
+    it("should create initiative with multiple policy definitions", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Multiple Policy Initiative",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+            policyDefinitionReferenceId: "policy1",
+          },
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-2",
+            policyDefinitionReferenceId: "policy2",
+          },
+          {
+            policyDefinitionId:
+              "/subscriptions/sub-id/providers/Microsoft.Authorization/policyDefinitions/custom-policy",
+            policyDefinitionReferenceId: "customPolicy",
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(
+        stack,
+        "MultiplePolicies",
+        props,
+      );
+      expect(policySet.policyDefinitionCount).toBe(3);
+    });
+
+    it("should create initiative with policy parameters", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Parameterized Initiative",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+            policyDefinitionReferenceId: "tagPolicy",
+            parameters: {
+              tagName: { value: "environment" },
+              tagValue: { value: "production" },
+            },
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(
+        stack,
+        "ParameterizedPolicy",
+        props,
+      );
+      expect(
+        policySet.props.policyDefinitions[0].parameters?.tagName.value,
+      ).toBe("environment");
+    });
+  });
+
+  // =============================================================================
+  // Initiative Parameters
+  // =============================================================================
+
+  describe("Initiative Parameters", () => {
+    it("should create initiative with parameter definitions", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Initiative With Parameters",
+        scope: "/subscriptions/test-sub",
+        parameters: {
+          allowedLocations: {
+            type: "Array",
+            displayName: "Allowed Locations",
+            description: "List of allowed Azure regions",
+            defaultValue: ["eastus", "westus2"],
+            allowedValues: [["eastus"], ["westus2"], ["eastus", "westus2"]],
+          },
+          requiredTag: {
+            type: "String",
+            displayName: "Required Tag",
+            description: "Name of the required tag",
+            defaultValue: "environment",
+          },
+        },
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+            parameters: {
+              listOfAllowedLocations: {
+                value: "[parameters('allowedLocations')]",
+              },
+            },
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(stack, "WithParams", props);
+      expect(policySet.props.parameters?.allowedLocations.type).toBe("Array");
+      expect(policySet.props.parameters?.requiredTag.type).toBe("String");
+    });
+
+    it("should create initiative with strong typed parameter", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Strong Typed Parameters",
+        scope: "/subscriptions/test-sub",
+        parameters: {
+          storageAccountSku: {
+            type: "String",
+            displayName: "Storage Account SKU",
+            metadata: {
+              strongType: "storageSkus",
+              displayName: "Storage SKU",
+            },
+          },
+        },
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(
+        stack,
+        "StrongTypedParams",
+        props,
+      );
+      expect(
+        policySet.props.parameters?.storageAccountSku.metadata?.strongType,
+      ).toBe("storageSkus");
+    });
+  });
+
+  // =============================================================================
+  // Policy Definition Groups
+  // =============================================================================
+
+  describe("Policy Definition Groups", () => {
+    it("should create initiative with groups", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Grouped Policies Initiative",
+        scope: "/subscriptions/test-sub",
+        policyDefinitionGroups: [
+          {
+            name: "Security",
+            displayName: "Security Policies",
+            category: "Security Center",
+            description: "Policies related to security",
+          },
+          {
+            name: "Compliance",
+            displayName: "Compliance Policies",
+            category: "Regulatory Compliance",
+          },
+        ],
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+            groupNames: ["Security"],
+          },
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-2",
+            groupNames: ["Compliance"],
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(
+        stack,
+        "GroupedPolicies",
+        props,
+      );
+      expect(policySet.props.policyDefinitionGroups?.length).toBe(2);
+      expect(policySet.props.policyDefinitionGroups?.[0].name).toBe("Security");
+    });
+
+    it("should allow policy definitions in multiple groups", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Multi-Group Policy Initiative",
+        scope: "/subscriptions/test-sub",
+        policyDefinitionGroups: [
+          { name: "Security" },
+          { name: "Compliance" },
+          { name: "Operations" },
+        ],
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+            groupNames: ["Security", "Compliance"],
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(
+        stack,
+        "MultiGroupPolicy",
+        props,
+      );
+      expect(policySet.props.policyDefinitions[0].groupNames?.length).toBe(2);
+    });
+  });
+
+  // =============================================================================
+  // Property Transformation
+  // =============================================================================
+
+  describe("Property Transformation", () => {
+    it("should generate correct Azure API format via createResourceBody", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Transform Test Initiative",
+        description: "Test transformation",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+            policyDefinitionReferenceId: "policy1",
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(stack, "TransformTest", props);
+
+      // Access the protected createResourceBody method
+      const resourceBody = (policySet as any).createResourceBody(props);
+
+      expect(resourceBody).toHaveProperty("properties");
+      expect(resourceBody.properties).toHaveProperty(
+        "displayName",
+        "Transform Test Initiative",
+      );
+      expect(resourceBody.properties).toHaveProperty(
+        "description",
+        "Test transformation",
+      );
+      expect(resourceBody.properties).toHaveProperty("policyType", "Custom");
+      expect(resourceBody.properties.policyDefinitions).toHaveLength(1);
+    });
+
+    it("should include metadata when specified", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Metadata Test",
+        scope: "/subscriptions/test-sub",
+        metadata: {
+          category: "Testing",
+          version: "2.0.0",
+        },
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(stack, "MetadataTest", props);
+      const resourceBody = (policySet as any).createResourceBody(props);
+
+      expect(resourceBody.properties.metadata).toBeDefined();
+      expect(resourceBody.properties.metadata.category).toBe("Testing");
+    });
+
+    it("should include parameters when specified", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Parameters Test",
+        scope: "/subscriptions/test-sub",
+        parameters: {
+          testParam: {
+            type: "String",
+            defaultValue: "test",
+          },
+        },
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(stack, "ParametersTest", props);
+      const resourceBody = (policySet as any).createResourceBody(props);
+
+      expect(resourceBody.properties.parameters).toBeDefined();
+      expect(resourceBody.properties.parameters.testParam.type).toBe("String");
+    });
+
+    it("should include policyDefinitionGroups when specified", () => {
+      const props: PolicySetDefinitionProps = {
+        displayName: "Groups Test",
+        scope: "/subscriptions/test-sub",
+        policyDefinitionGroups: [
+          { name: "TestGroup", displayName: "Test Group" },
+        ],
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+            groupNames: ["TestGroup"],
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(stack, "GroupsTest", props);
+      const resourceBody = (policySet as any).createResourceBody(props);
+
+      expect(resourceBody.properties.policyDefinitionGroups).toBeDefined();
+      expect(resourceBody.properties.policyDefinitionGroups).toHaveLength(1);
+    });
+  });
+
+  // =============================================================================
+  // Integration with Base Class
+  // =============================================================================
+
+  describe("Integration with Base Class", () => {
+    it("should inherit from AzapiResource", () => {
+      const policySet = new PolicySetDefinition(stack, "InheritanceTest", {
+        displayName: "Inheritance Test",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      });
+
+      // Verify it has AzapiResource properties
+      expect(policySet).toHaveProperty("terraformResource");
+      expect(policySet).toHaveProperty("resolvedApiVersion");
+    });
+
+    it("should have correct resourceType", () => {
+      const policySet = new PolicySetDefinition(stack, "ResourceTypeTest", {
+        displayName: "Resource Type Test",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      });
+
+      // Access the protected resourceType method
+      const resourceType = (policySet as any).resourceType();
+      expect(resourceType).toBe("Microsoft.Authorization/policySetDefinitions");
+    });
+
+    it("should resolve parent ID correctly", () => {
+      const scope = "/subscriptions/test-sub";
+
+      const props: PolicySetDefinitionProps = {
+        displayName: "Parent ID Test",
+        scope,
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(stack, "ParentIdTest", props);
+
+      // Access the protected resolveParentId method
+      const parentId = (policySet as any).resolveParentId(props);
+      expect(parentId).toBe(scope);
+    });
+
+    it("should generate resource outputs", () => {
+      const policySet = new PolicySetDefinition(stack, "OutputsTest", {
+        displayName: "Outputs Test",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      });
+
+      expect(policySet.idOutput).toBeInstanceOf(cdktf.TerraformOutput);
+      expect(policySet.nameOutput).toBeInstanceOf(cdktf.TerraformOutput);
+      expect(policySet.policySetDefinitionIdOutput).toBeInstanceOf(
+        cdktf.TerraformOutput,
+      );
+      expect(policySet.id).toMatch(/^\$\{.*\.id\}$/);
+    });
+  });
+
+  // =============================================================================
+  // CDK Terraform Integration
+  // =============================================================================
+
+  describe("CDK Terraform Integration", () => {
+    it("should synthesize to valid Terraform configuration", () => {
+      new PolicySetDefinition(stack, "SynthTest", {
+        displayName: "Synth Test Initiative",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+            policyDefinitionReferenceId: "testPolicy",
+          },
+        ],
+      });
+
+      const synthesized = Testing.synth(stack);
+      expect(synthesized).toBeDefined();
+
+      const stackConfig = JSON.parse(synthesized);
+      expect(stackConfig.resource).toBeDefined();
+    });
+
+    it("should handle multiple policy sets in the same stack", () => {
+      const policySet1 = new PolicySetDefinition(stack, "PolicySet1", {
+        displayName: "Policy Set 1",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      });
+
+      const policySet2 = new PolicySetDefinition(stack, "PolicySet2", {
+        displayName: "Policy Set 2",
+        scope: "/subscriptions/test-sub",
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-2",
+          },
+        ],
+        apiVersion: "2021-06-01",
+      });
+
+      expect(policySet1.resolvedApiVersion).toBe("2023-04-01");
+      expect(policySet2.resolvedApiVersion).toBe("2021-06-01");
+
+      const synthesized = Testing.synth(stack);
+      expect(synthesized).toBeDefined();
+    });
+  });
+
+  // =============================================================================
+  // Complex Scenarios
+  // =============================================================================
+
+  describe("Complex Scenarios", () => {
+    it("should handle comprehensive initiative configuration", () => {
+      const props: PolicySetDefinitionProps = {
+        name: "comprehensive-initiative",
+        displayName: "Comprehensive Security & Compliance Initiative",
+        description:
+          "This initiative enforces security and compliance policies across the organization.",
+        scope: "/providers/Microsoft.Management/managementGroups/my-mg",
+        policyType: "Custom",
+        metadata: {
+          category: "Security Center",
+          version: "3.0.0",
+          preview: false,
+          deprecated: false,
+        },
+        parameters: {
+          allowedLocations: {
+            type: "Array",
+            displayName: "Allowed Locations",
+            description: "The list of allowed Azure regions",
+            defaultValue: ["eastus", "westus2", "centralus"],
+            metadata: {
+              strongType: "location",
+              displayName: "Locations",
+            },
+          },
+          requiredTagName: {
+            type: "String",
+            displayName: "Required Tag Name",
+            defaultValue: "costCenter",
+          },
+          effect: {
+            type: "String",
+            displayName: "Effect",
+            description: "The effect of the policy",
+            defaultValue: "Audit",
+            allowedValues: ["Audit", "Deny", "Disabled"],
+          },
+        },
+        policyDefinitionGroups: [
+          {
+            name: "Security",
+            displayName: "Security Policies",
+            category: "Security Center",
+            description: "Policies ensuring security best practices",
+          },
+          {
+            name: "Compliance",
+            displayName: "Compliance Policies",
+            category: "Regulatory Compliance",
+            description: "Policies for regulatory compliance",
+          },
+          {
+            name: "Tagging",
+            displayName: "Tagging Policies",
+            category: "Tags",
+            description: "Policies for consistent resource tagging",
+          },
+        ],
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/e56962a6-4747-49cd-b67b-bf8b01975c4c",
+            policyDefinitionReferenceId: "allowedLocations",
+            parameters: {
+              listOfAllowedLocations: {
+                value: "[parameters('allowedLocations')]",
+              },
+            },
+            groupNames: ["Security", "Compliance"],
+          },
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/96670d01-0a4d-4649-9c89-2d3abc0a5025",
+            policyDefinitionReferenceId: "requireTag",
+            parameters: {
+              tagName: { value: "[parameters('requiredTagName')]" },
+            },
+            groupNames: ["Tagging"],
+          },
+          {
+            policyDefinitionId:
+              "/subscriptions/test-sub/providers/Microsoft.Authorization/policyDefinitions/custom-security-policy",
+            policyDefinitionReferenceId: "customSecurityPolicy",
+            parameters: {
+              effect: { value: "[parameters('effect')]" },
+            },
+            groupNames: ["Security"],
+          },
+        ],
+        tags: {
+          environment: "production",
+          team: "security",
+          managedBy: "terraform-cdk",
+        },
+      };
+
+      const policySet = new PolicySetDefinition(
+        stack,
+        "ComprehensiveConfig",
+        props,
+      );
+      const resourceBody = (policySet as any).createResourceBody(props);
+
+      expect(resourceBody.properties.displayName).toBe(
+        "Comprehensive Security & Compliance Initiative",
+      );
+      expect(resourceBody.properties.policyType).toBe("Custom");
+      expect(resourceBody.properties.metadata.category).toBe("Security Center");
+      expect(resourceBody.properties.parameters.allowedLocations.type).toBe(
+        "Array",
+      );
+      expect(resourceBody.properties.policyDefinitionGroups).toHaveLength(3);
+      expect(resourceBody.properties.policyDefinitions).toHaveLength(3);
+      expect(resourceBody.properties.policyDefinitions[0].groupNames).toContain(
+        "Security",
+      );
+    });
+
+    it("should handle management group scope", () => {
+      const mgScope =
+        "/providers/Microsoft.Management/managementGroups/my-management-group";
+
+      const props: PolicySetDefinitionProps = {
+        displayName: "Management Group Initiative",
+        scope: mgScope,
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(
+        stack,
+        "MgScopeInitiative",
+        props,
+      );
+      const parentId = (policySet as any).resolveParentId(props);
+
+      expect(parentId).toBe(mgScope);
+    });
+
+    it("should handle subscription scope", () => {
+      const subScope = "/subscriptions/00000000-0000-0000-0000-000000000000";
+
+      const props: PolicySetDefinitionProps = {
+        displayName: "Subscription Initiative",
+        scope: subScope,
+        policyDefinitions: [
+          {
+            policyDefinitionId:
+              "/providers/Microsoft.Authorization/policyDefinitions/policy-1",
+          },
+        ],
+      };
+
+      const policySet = new PolicySetDefinition(
+        stack,
+        "SubScopeInitiative",
+        props,
+      );
+      const parentId = (policySet as any).resolveParentId(props);
+
+      expect(parentId).toBe(subScope);
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@
  * - azure_actiongroup: Azure Action Group constructs for Azure Monitor alerts
  * - azure_activitylogalert: Azure Activity Log Alert constructs for operation monitoring
  * - azure_aks: Azure Kubernetes Service constructs with version-aware AZAPI implementation
+ * - azure_loganalyticsworkspace: Log Analytics Workspace constructs for log data collection
  * - azure_diagnosticsettings: Azure Diagnostic Settings constructs for monitoring and observability
  * - azure_dnsforwardingruleset: DNS Forwarding Ruleset constructs for private DNS resolution
  * - azure_dnsresolver: DNS Resolver constructs for private DNS resolution
@@ -16,8 +17,10 @@
  * - azure_metricalert: Azure Metric Alert constructs for metric-based alerting
  * - azure_networkinterface: Network Interface constructs with version-aware AZAPI implementation
  * - azure_networksecuritygroup: Network Security Group constructs with version-aware AZAPI implementation
+ * - azure_networkwatcher: Network Watcher constructs for network monitoring and diagnostics
  * - azure_policyassignment: Policy Assignment constructs for Azure Policy
  * - azure_policydefinition: Policy Definition constructs for custom Azure policies
+ * - azure_policysetdefinition: Policy Set Definition (Initiative) constructs for grouping policies
  * - azure_privatednszone: Private DNS Zone constructs with DNS record management
  * - azure_privatednszonelink: Private DNS Zone Link constructs for VNet linking
  * - azure_publicipaddress: Public IP Address constructs with version-aware AZAPI implementation
@@ -51,13 +54,16 @@ export * as azure_activitylogalert from "./azure-activitylogalert";
 export * as azure_aks from "./azure-aks";
 export * as azure_diagnosticsettings from "./azure-diagnosticsettings";
 export * as azure_dnsforwardingruleset from "./azure-dnsforwardingruleset";
+export * as azure_loganalyticsworkspace from "./azure-loganalyticsworkspace";
 export * as azure_dnsresolver from "./azure-dnsresolver";
 export * as azure_dnszone from "./azure-dnszone";
 export * as azure_metricalert from "./azure-metricalert";
 export * as azure_networkinterface from "./azure-networkinterface";
 export * as azure_networksecuritygroup from "./azure-networksecuritygroup";
+export * as azure_networkwatcher from "./azure-networkwatcher";
 export * as azure_policyassignment from "./azure-policyassignment";
 export * as azure_policydefinition from "./azure-policydefinition";
+export * as azure_policysetdefinition from "./azure-policysetdefinition";
 export * as azure_privatednszone from "./azure-privatednszone";
 export * as azure_privatednszonelink from "./azure-privatednszonelink";
 export * as azure_publicipaddress from "./azure-publicipaddress";
@@ -80,12 +86,15 @@ export * from "./azure-aks";
 export * from "./azure-diagnosticsettings";
 export * from "./azure-dnsforwardingruleset";
 export * from "./azure-dnsresolver";
+export * from "./azure-loganalyticsworkspace";
 export * from "./azure-dnszone";
 export * from "./azure-metricalert";
 export * from "./azure-networkinterface";
 export * from "./azure-networksecuritygroup";
+export * from "./azure-networkwatcher";
 export * from "./azure-policyassignment";
 export * from "./azure-policydefinition";
+export * from "./azure-policysetdefinition";
 export * from "./azure-privatednszone";
 export * from "./azure-privatednszonelink";
 export * from "./azure-publicipaddress";

--- a/yarn.lock
+++ b/yarn.lock
@@ -278,24 +278,24 @@
     "@jridgewell/trace-mapping" "0.3.9"
 
 "@emnapi/core@^1.4.3":
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.8.1.tgz#fd9efe721a616288345ffee17a1f26ac5dd01349"
-  integrity sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.9.0.tgz#4a54213b208fcf288cce25076c74e0f7613e6100"
+  integrity sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==
   dependencies:
-    "@emnapi/wasi-threads" "1.1.0"
+    "@emnapi/wasi-threads" "1.2.0"
     tslib "^2.4.0"
 
 "@emnapi/runtime@^1.4.3":
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.8.1.tgz#550fa7e3c0d49c5fb175a116e8cd70614f9a22a5"
-  integrity sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.9.0.tgz#91c54a6e77c36154c125e873409472e2b70efd5b"
+  integrity sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==
   dependencies:
     tslib "^2.4.0"
 
-"@emnapi/wasi-threads@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz#60b2102fddc9ccb78607e4a3cf8403ea69be41bf"
-  integrity sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==
+"@emnapi/wasi-threads@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz#a19d9772cc3d195370bf6e2a805eec40aa75e18e"
+  integrity sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==
   dependencies:
     tslib "^2.4.0"
 
@@ -1408,9 +1408,9 @@ bare-fs@^4.5.5:
     fast-fifo "^1.3.2"
 
 bare-os@^3.0.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/bare-os/-/bare-os-3.7.1.tgz#ec06b7b91a6638e307859803456a49760740a58f"
-  integrity sha512-ebvMaS5BgZKmJlvuWh14dg9rbUI84QeV3WlWn6Ph6lFI8jJoh7ADtVTyD2c93euwbe+zgi0DVrl4YmqXeM9aIA==
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/bare-os/-/bare-os-3.8.0.tgz#888541d443914e861abed02657a6ef1c50bbf383"
+  integrity sha512-Dc9/SlwfxkXIGYhvMQNUtKaXCaGkZYGcd1vuNUUADVqzu4/vQfvnMkYYOUnt2VwQ2AqKr/8qAVFRtwETljgeFg==
 
 bare-path@^3.0.0:
   version "3.0.0"
@@ -1420,9 +1420,9 @@ bare-path@^3.0.0:
     bare-os "^3.0.1"
 
 bare-stream@^2.6.4:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/bare-stream/-/bare-stream-2.8.0.tgz#3ac6141a65d097fd2bf6e472c848c5d800d47df9"
-  integrity sha512-reUN0M2sHRqCdG4lUK3Fw8w98eeUIZHL5c3H7Mbhk2yVBL+oofgaIp0ieLfD5QXwPCypBpmEEKU2WZKzbAk8GA==
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/bare-stream/-/bare-stream-2.8.1.tgz#a4551375bcb01484c5a66946652ebd718b47903d"
+  integrity sha512-bSeR8RfvbRwDpD7HWZvn8M3uYNDrk7m9DQjYOFkENZlXW8Ju/MPaqUPQq5LqJ3kyjEm07siTaAQ7wBKCU59oHg==
   dependencies:
     streamx "^2.21.0"
     teex "^1.0.1"


### PR DESCRIPTION
Add three new constructs ported from the 1.x branch (using cdktn instead of cdktf):

- **azure-loganalyticsworkspace**: Log Analytics Workspace construct for log data collection
- **azure-networkwatcher**: Network Watcher construct for network monitoring and diagnostics
- **azure-policysetdefinition**: Policy Set Definition (Initiative) construct for grouping policies

Each construct includes schemas, implementation, unit tests, integration tests, and documentation.