### PR TITLE
chore: list the Bastion Host construct in the supported-services table

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ With AZAPI L2 Constructs, you get the following benefits:
 | [Network Interfaces](./src/azure-networkinterface/README.md) | 2024-07-01, 2024-10-01, 2025-01-01 | ✅ Available |
 | [Network Security Groups](./src/azure-networksecuritygroup/README.md) | 2024-07-01, 2024-10-01, 2025-01-01 | ✅ Available |
 | [Public IP Addresses](./src/azure-publicipaddress/README.md) | 2024-07-01, 2024-10-01, 2025-01-01 | ✅ Available |
+| [Bastion Hosts](./src/azure-bastionhost/README.md) | 2024-07-01, 2024-10-01 | ✅ Available |
 
 ### Monitoring & Alerting
 


### PR DESCRIPTION
The **Currently Supported Services** tables are how this library is discovered — each row
links to that construct's own README. The Bastion Host construct merged in #121 with a
complete README at `src/azure-bastionhost/README.md` and an export in `src/index.ts`, but it
was never added to the table, so today it is only findable by someone who already knows it
exists.

Adds one row to **Networking**:

```
| [Bastion Hosts](./src/azure-bastionhost/README.md) | 2024-07-01, 2024-10-01 | ✅ Available |
```

### On the API versions

Listed as `2024-07-01, 2024-10-01` to match what the construct actually implements —
`BASTION_HOST_SCHEMA_2024_07_01` and `BASTION_HOST_SCHEMA_2024_10_01` in
`lib/bastion-host-schemas.ts`, corroborated by the header comment in `lib/bastion-host.ts`
marking them *Active* and *Active, Latest*.

The other Networking rows also list `2025-01-01`. This construct does not support that
version yet, so I deliberately did not claim it rather than making the row look uniform.

Docs only — no code paths touched.